### PR TITLE
fix debug cvar not functioning

### DIFF
--- a/addons/sourcemod/scripting/customvotes.sp
+++ b/addons/sourcemod/scripting/customvotes.sp
@@ -201,6 +201,7 @@ public OnConVarChanged( Handle:hConVar, const String:strOldValue[], const String
 	bAutoBanType = GetConVarBool( CvarAutoBanType );
 	iAutoBanDuration = GetConVarInt( CvarAutoBanDuration );
 	bCancelVoteGameEnd = GetConVarBool( CvarCancelVoteGameEnd );
+	bDebugMode = GetConVarBool( CvarDebugMode );
 }
 
 stock DetectGame()


### PR DESCRIPTION
I was wondering why I wasn't seeing debug messages even with the cvar enabled, it was because bDebugMode was never set by the cvar, this PR fixes that.