### PR TITLE
Update Multi Colors to 2.1.2, fixing bug:

### DIFF
--- a/addons/sourcemod/scripting/include/multicolors.inc
+++ b/addons/sourcemod/scripting/include/multicolors.inc
@@ -3,8 +3,7 @@
 #endif
 #define _multicolors_included
 
-#define MuCo_VERSION "2.1.1"
-#define MuCo_LoopClients(%1) for(int %1 = 1; %1 <= MaxClients; %1++)
+#define MuCo_VERSION "2.1.2"
 
 #include <multicolors/morecolors>
 #include <multicolors/colors>
@@ -28,9 +27,9 @@
 #define PREFIX_SEPARATOR "{default} "
 
 /* Global var to check whether colors are fixed or not */
-static bool g_bCFixColors = false;
+static bool g_bCFixColors;
 
-static char g_sPrefix[PREFIX_MAX_LENGTH];
+static char g_sCPrefix[PREFIX_MAX_LENGTH];
 
 /**
  * Add a chat prefix before all chat msg
@@ -38,13 +37,15 @@ static char g_sPrefix[PREFIX_MAX_LENGTH];
  * @param sPrefix		Prefix
  */
 stock void CSetPrefix(const char[] sPrefix, any ...) {
-	if (!sPrefix[0])
+	if (!sPrefix[0]) {
 		return;
+	}
 
-	VFormat(g_sPrefix, sizeof(g_sPrefix) - strlen(PREFIX_SEPARATOR), sPrefix, 2);
+	SetGlobalTransTarget(LANG_SERVER);
+	VFormat(g_sCPrefix, sizeof(g_sCPrefix) - strlen(PREFIX_SEPARATOR), sPrefix, 2);
 
 	// Add ending space
-	Format(g_sPrefix, sizeof(g_sPrefix), "%s%s", g_sPrefix, PREFIX_SEPARATOR);
+	Format(g_sCPrefix, sizeof(g_sCPrefix), "%s%s", g_sCPrefix, PREFIX_SEPARATOR);
 }
 
 /**
@@ -53,7 +54,7 @@ stock void CSetPrefix(const char[] sPrefix, any ...) {
  * @param sPrefix		Prefix
  */
 stock void CClearPrefix() {
-	g_sPrefix[0] = '\0';
+	g_sCPrefix[0] = '\0';
 }
 
 /**
@@ -64,21 +65,22 @@ stock void CClearPrefix() {
  *
  * @error               If the client is not connected an error will be thrown.
  */
-stock void CPrintToChat(int client, const char[] message, any ...)
-{
+stock void CPrintToChat(int client, const char[] message, any ...) {
 	char buffer[MAX_MESSAGE_LENGTH];
+	SetGlobalTransTarget(client);
 	VFormat(buffer, sizeof(buffer), message, 3);
 
-	if (!g_bCFixColors)
+	if (!g_bCFixColors) {
 		CFixColors();
+	}
 
-	if (!IsSource2009())
-		C_PrintToChat(client, "%s%s", g_sPrefix, buffer);
-	else
-		MC_PrintToChat(client, "%s%s", g_sPrefix, buffer);
+	if (!IsSource2009()) {
+		C_PrintToChat(client, "%s%s", g_sCPrefix, buffer);
+	}
+	else {
+		MC_PrintToChat(client, "%s%s", g_sCPrefix, buffer);
+	}
 }
-
-
 
 /**
  * Prints a message to all clients in the chat area.
@@ -87,18 +89,43 @@ stock void CPrintToChat(int client, const char[] message, any ...)
  * @param client	  Client index.
  * @param message     Message (formatting rules)
  */
-stock void CPrintToChatAll(const char[] message, any ...)
-{
-	char buffer[MAX_MESSAGE_LENGTH];
-	VFormat(buffer, sizeof(buffer), message, 2);
-
-	if (!g_bCFixColors)
+stock void CPrintToChatAll(const char[] message, any ...) {
+	if (!g_bCFixColors) {
 		CFixColors();
+	}
 
-	if (!IsSource2009())
-		C_PrintToChatAll("%s%s", g_sPrefix, buffer);
-	else
-		MC_PrintToChatAll("%s%s", g_sPrefix, buffer);
+	char buffer[MAX_BUFFER_LENGTH];
+	if (!IsSource2009()) {
+		for (int i = 1; i <= MaxClients; ++i) {
+			if (IsClientInGame(i) && !IsFakeClient(i) && !C_SkipList[i]) {
+				SetGlobalTransTarget(i);
+				VFormat(buffer, sizeof(buffer), message, 2);
+
+				C_PrintToChat(i, "%s", buffer);
+			}
+
+			C_SkipList[i] = false;
+		}
+	}
+	else {
+		MC_CheckTrie();
+
+		char buffer2[MAX_BUFFER_LENGTH];
+
+		for (int i = 1; i <= MaxClients; ++i) {
+			if (!IsClientInGame(i) || MC_SkipList[i]) {
+				MC_SkipList[i] = false;
+				continue;
+			}
+
+			SetGlobalTransTarget(i);
+			Format(buffer, sizeof(buffer), "\x01%s", message);
+			VFormat(buffer2, sizeof(buffer2), buffer, 2);
+
+			MC_ReplaceColorCodes(buffer2);
+			MC_SendMessage(i, buffer2);
+		}
+	}
 }
 
 /**
@@ -107,29 +134,26 @@ stock void CPrintToChatAll(const char[] message, any ...)
  * @param target 	Client index.
  * @param message	Message (formatting rules).
  */
-stock void CPrintToChatObservers(int target, const char[] message, any ...)
-{
+stock void CPrintToChatObservers(int target, const char[] message, any ...) {
 	char buffer[MAX_MESSAGE_LENGTH];
+	SetGlobalTransTarget(LANG_SERVER);
 	VFormat(buffer, sizeof(buffer), message, 3);
 
-	if (!g_bCFixColors)
+	if (!g_bCFixColors) {
 		CFixColors();
+	}
 
- 	for(int client = 1; client <= MaxClients; client++)
-	{
- 		if(IsClientInGame(client) && !IsPlayerAlive(client) && !IsFakeClient(client))
-		{
- 			int observee 		= GetEntPropEnt(client, Prop_Send, "m_hObserverTarget");
- 			int ObserverMode 	= GetEntProp(client, Prop_Send, "m_iObserverMode");
+ 	for (int client = 1; client <= MaxClients; client++) {
+ 		if (IsClientInGame(client) && !IsPlayerAlive(client) && !IsFakeClient(client)) {
+ 			int observee = GetEntPropEnt(client, Prop_Send, "m_hObserverTarget");
+ 			int ObserverMode = GetEntProp(client, Prop_Send, "m_iObserverMode");
  
- 			if(observee == target && (ObserverMode == 4 || ObserverMode == 5))
-			{
+ 			if (observee == target && (ObserverMode == 4 || ObserverMode == 5)) {
  				CPrintToChat(client, buffer);
  			}
  		}
  	}
 }
-
 
 /**
  * Writes a message to a client with the correct stock for the game.
@@ -140,18 +164,21 @@ stock void CPrintToChatObservers(int target, const char[] message, any ...)
  *
  * @error               If the client is not connected an error will be thrown.
  */
-stock void CPrintToChatEx(int client, int author, const char[] message, any ...)
-{
+stock void CPrintToChatEx(int client, int author, const char[] message, any ...) {
 	char buffer[MAX_MESSAGE_LENGTH];
+	SetGlobalTransTarget(client);
 	VFormat(buffer, sizeof(buffer), message, 4);
 
-	if (!g_bCFixColors)
+	if (!g_bCFixColors) {
 		CFixColors();
+	}
 
-	if (!IsSource2009())
-		C_PrintToChatEx(client, author, "%s%s", g_sPrefix, buffer);
-	else
-		MC_PrintToChatEx(client, author, "%s%s", g_sPrefix, buffer);
+	if (!IsSource2009()) {
+		C_PrintToChatEx(client, author, "%s%s", g_sCPrefix, buffer);
+	}
+	else {
+		MC_PrintToChatEx(client, author, "%s%s", g_sCPrefix, buffer);
+	}
 }
 
 /**
@@ -160,18 +187,21 @@ stock void CPrintToChatEx(int client, int author, const char[] message, any ...)
  * @param author        Author index.
  * @param message       Message (formatting rules).
  */
-stock void CPrintToChatAllEx(int author, const char[] message, any ...)
-{
+stock void CPrintToChatAllEx(int author, const char[] message, any ...) {
 	char buffer[MAX_MESSAGE_LENGTH];
+	SetGlobalTransTarget(LANG_SERVER);
 	VFormat(buffer, sizeof(buffer), message, 3);
 
-	if (!g_bCFixColors)
+	if (!g_bCFixColors) {
 		CFixColors();
+	}
 
-	if (!IsSource2009())
-		C_PrintToChatAllEx(author, "%s%s", g_sPrefix, buffer);
-	else
-		MC_PrintToChatAllEx(author, "%s%s", g_sPrefix, buffer);
+	if (!IsSource2009()) {
+		C_PrintToChatAllEx(author, "%s%s", g_sCPrefix, buffer);
+	}
+	else {
+		MC_PrintToChatAllEx(author, "%s%s", g_sCPrefix, buffer);
+	}
 }
 
 /**
@@ -181,29 +211,26 @@ stock void CPrintToChatAllEx(int author, const char[] message, any ...)
  * @param target 	Client index.
  * @param message	Message (formatting rules).
  */
-stock void CPrintToChatObserversEx(int target, const char[] message, any ...)
-{
+stock void CPrintToChatObserversEx(int target, const char[] message, any ...) {
 	char buffer[MAX_MESSAGE_LENGTH];
+	SetGlobalTransTarget(LANG_SERVER);
 	VFormat(buffer, sizeof(buffer), message, 3);
 
-	if (!g_bCFixColors)
+	if (!g_bCFixColors) {
 		CFixColors();
+	}
 
- 	for(int client = 1; client <= MaxClients; client++)
-	{
- 		if(IsClientInGame(client) && !IsPlayerAlive(client) && !IsFakeClient(client))
-		{
- 			int observee 		= GetEntPropEnt(client, Prop_Send, "m_hObserverTarget");
- 			int ObserverMode 	= GetEntProp(client, Prop_Send, "m_iObserverMode");
+ 	for (int client = 1; client <= MaxClients; client++) {
+ 		if (IsClientInGame(client) && !IsPlayerAlive(client) && !IsFakeClient(client)) {
+ 			int observee = GetEntPropEnt(client, Prop_Send, "m_hObserverTarget");
+ 			int ObserverMode = GetEntProp(client, Prop_Send, "m_iObserverMode");
  
- 			if(observee == target && (ObserverMode == 4 || ObserverMode == 5))
-			{
+ 			if (observee == target && (ObserverMode == 4 || ObserverMode == 5)) {
  				CPrintToChatEx(client, target, buffer);
  			}
  		}
  	}
 }
-
 
 /**
  * Replies to a command with colors
@@ -211,21 +238,22 @@ stock void CPrintToChatObserversEx(int target, const char[] message, any ...)
  * @param client		Client to reply to
  * @param message		Message (formatting rules)
  */
-stock void CReplyToCommand(int author, const char[] message, any ...)
-{
+stock void CReplyToCommand(int client, const char[] message, any ...) {
 	char buffer[MAX_MESSAGE_LENGTH];
+	SetGlobalTransTarget(client);
 	VFormat(buffer, sizeof(buffer), message, 3);
 
-	if (!g_bCFixColors)
+	if (!g_bCFixColors) {
 		CFixColors();
+	}
 
-	if (!IsSource2009())
-		C_ReplyToCommand(author, "%s%s", g_sPrefix, buffer);
-	else
-		MC_ReplyToCommand(author, "%s%s", g_sPrefix, buffer);
+	if (!IsSource2009()) {
+		C_ReplyToCommand(client, "%s%s", g_sCPrefix, buffer);
+	}
+	else {
+		MC_ReplyToCommand(client, "%s%s", g_sCPrefix, buffer);
+	}
 }
-
-
 
 /**
  * Replies to a command with colors
@@ -234,19 +262,21 @@ stock void CReplyToCommand(int author, const char[] message, any ...)
  * @param author		Client to use for {teamcolor}
  * @param message		Message (formatting rules)
  */
- stock void CReplyToCommandEx(int client, int author, const char[] message, any ...)
-{
+stock void CReplyToCommandEx(int client, int author, const char[] message, any ...) {
 	char buffer[MAX_MESSAGE_LENGTH];
-
+	SetGlobalTransTarget(client);
 	VFormat(buffer, sizeof(buffer), message, 4);
 
-	if (!g_bCFixColors)
+	if (!g_bCFixColors) {
 		CFixColors();
+	}
 
-	if (!IsSource2009())
-		C_ReplyToCommandEx(client, author, "%s%s", g_sPrefix, buffer);
-	else
-		MC_ReplyToCommandEx(client, author, "%s%s", g_sPrefix, buffer);
+	if (!IsSource2009()) {
+		C_ReplyToCommandEx(client, author, "%s%s", g_sCPrefix, buffer);
+	}
+	else {
+		MC_ReplyToCommandEx(client, author, "%s%s", g_sCPrefix, buffer);
+	}
 }
 
 /**
@@ -254,24 +284,22 @@ stock void CReplyToCommand(int author, const char[] message, any ...)
  * 
  * @param message		Message (formatting rules)
  */
- stock void CPrintToServer(const char[] message, any ...)
-{
+stock void CPrintToServer(const char[] message, any ...) {
 	char buffer[MAX_MESSAGE_LENGTH];
 	char prefixBuffer[PREFIX_MAX_LENGTH];
-
+	SetGlobalTransTarget(LANG_SERVER);
 	VFormat(buffer, sizeof(buffer), message, 2);
-	strcopy(prefixBuffer, sizeof(prefixBuffer), g_sPrefix);
+	strcopy(prefixBuffer, sizeof(prefixBuffer), g_sCPrefix);
 
-	if (!g_bCFixColors)
+	if (!g_bCFixColors) {
 		CFixColors();
+	}
 
 	CRemoveTags(buffer, sizeof(buffer));
 	CRemoveTags(prefixBuffer, sizeof(prefixBuffer));
 
 	PrintToServer("%s%s", prefixBuffer, buffer);
 }
-
-
 
 /**
  * Displays usage of an admin command to users depending on the 
@@ -289,20 +317,22 @@ stock void CReplyToCommand(int author, const char[] message, any ...)
  * 
  * @error
  */
-stock void CShowActivity(int author, const char[] message, any ...)
-{
+stock void CShowActivity(int author, const char[] message, any ...) {
 	char buffer[MAX_MESSAGE_LENGTH];
+	SetGlobalTransTarget(LANG_SERVER);
 	VFormat(buffer, sizeof(buffer), message, 3);
 
-	if (!g_bCFixColors)
+	if (!g_bCFixColors) {
 		CFixColors();
+	}
 
-	if (!IsSource2009())
+	if (!IsSource2009()) {
 		C_ShowActivity(author, "%s", buffer);
-	else
+	}
+	else {
 		MC_ShowActivity(author, "%s", buffer);
+	}
 }
-
 
 /**
  * Same as C_ShowActivity(), except the tag parameter is used instead of "[SM] " (note that you must supply any spacing).
@@ -315,21 +345,22 @@ stock void CShowActivity(int author, const char[] message, any ...)
  * 
  * @error
  */
-stock void CShowActivityEx(int author, const char[] tag, const char[] message, any ...)
-{
+stock void CShowActivityEx(int author, const char[] tag, const char[] message, any ...) {
 	char buffer[MAX_MESSAGE_LENGTH];
+	SetGlobalTransTarget(LANG_SERVER);
 	VFormat(buffer, sizeof(buffer), message, 4);
 
-	if (!g_bCFixColors)
+	if (!g_bCFixColors) {
 		CFixColors();
+	}
 
-	if (!IsSource2009())
+	if (!IsSource2009()) {
 		C_ShowActivityEx(author, tag, "%s", buffer);
-	else
+	}
+	else {
 		MC_ShowActivityEx(author, tag, "%s", buffer);
+	}
 }
-
-
 
 /**
  * Displays usage of an admin command to users depending on the setting of the sm_show_activity cvar.
@@ -344,21 +375,22 @@ stock void CShowActivityEx(int author, const char[] tag, const char[] message, a
  * 
  * @error
  */
- stock void CShowActivity2(int author, const char[] tag, const char[] message, any ...)
-{
+ stock void CShowActivity2(int author, const char[] tag, const char[] message, any ...) {
 	char buffer[MAX_MESSAGE_LENGTH];
+	SetGlobalTransTarget(LANG_SERVER);
 	VFormat(buffer, sizeof(buffer), message, 4);
 
-	if (!g_bCFixColors)
+	if (!g_bCFixColors) {
 		CFixColors();
+	}
 
-	if (!IsSource2009())
+	if (!IsSource2009()) {
 		C_ShowActivity2(author, tag, "%s", buffer);
-	else
+	}
+	else {
 		MC_ShowActivity2(author, tag, "%s", buffer);
+	}
 }
-
-
 
 /**
  * Replaces color tags in a string with color codes
@@ -366,28 +398,26 @@ stock void CShowActivityEx(int author, const char[] tag, const char[] message, a
  * @param message       String.
  * @param maxlength     Maximum length of the string buffer.
  */
-stock void CFormatColor(char[] message, int maxlength, int author = -1)
-{
-	if (!g_bCFixColors)
+stock void CFormatColor(char[] message, int maxlength, int author = -1) {
+	if (!g_bCFixColors) {
 		CFixColors();
+	}
 
-	if (!IsSource2009())
-	{
-		if (author == 0)
+	if (!IsSource2009()) {
+		if (author == 0) {
 			author = -1;
+		}
 
 		C_Format(message, maxlength, author);
 	}
-	else
-	{
-		if (author == -1)
+	else {
+		if (author == -1) {
 			author = 0;
+		}
 
 		MC_ReplaceColorCodes(message, author, false, maxlength);
 	}
 }
-
-
 
 /**
  * Removes color tags from a message
@@ -395,48 +425,36 @@ stock void CFormatColor(char[] message, int maxlength, int author = -1)
  * @param message		Message to remove tags from
  * @param maxlen		Maximum buffer length
  */
-stock void CRemoveTags(char[] message, int maxlen)
-{
-	if (!IsSource2009())
-	{
+stock void CRemoveTags(char[] message, int maxlen) {
+	if (!IsSource2009()) {
 		C_RemoveTags(message, maxlen);
 	}
-	else
-	{
+	else {
 		MC_RemoveTags(message, maxlen);
 	}
 }
 
-
-
 /**
  * Fixes missing Lightgreen color.
  */
-stock void CFixColors()
-{
+stock void CFixColors() {
 	g_bCFixColors = true;
 
 	// Replace lightgreen if not exists
-	if (!C_ColorAllowed(Color_Lightgreen))
-	{
-		if (C_ColorAllowed(Color_Lime))
+	if (!C_ColorAllowed(Color_Lightgreen)) {
+		if (C_ColorAllowed(Color_Lime)) {
 			C_ReplaceColor(Color_Lightgreen, Color_Lime);
-		else if (C_ColorAllowed(Color_Olive))
+		}
+		else if (C_ColorAllowed(Color_Olive)) {
 			C_ReplaceColor(Color_Lightgreen, Color_Olive);
+		}
 	}
 }
 
-stock bool IsSource2009()
-{
-	if(
-		GetEngineVersion() == Engine_CSS ||
-		GetEngineVersion() == Engine_HL2DM ||
-		GetEngineVersion() == Engine_DODS ||
-		GetEngineVersion() == Engine_TF2 ||
-		GetEngineVersion() == Engine_SDK2013
-		)
-	{
-		return true;
-	}
-	return false;
+stock bool IsSource2009() {
+	return (GetEngineVersion() == Engine_CSS
+	|| GetEngineVersion() == Engine_HL2DM
+	|| GetEngineVersion() == Engine_DODS
+	|| GetEngineVersion() == Engine_TF2
+	|| GetEngineVersion() == Engine_SDK2013);
 }

--- a/addons/sourcemod/scripting/include/multicolors/colors.inc
+++ b/addons/sourcemod/scripting/include/multicolors/colors.inc
@@ -19,8 +19,7 @@
 #define NO_INDEX -1
 #define NO_PLAYER -2
 
-enum C_Colors
-{
+enum C_Colors {
  	Color_Default = 0,
 	Color_Darkred,
 	Color_Green,
@@ -46,15 +45,15 @@ enum C_Colors
 char C_Tag[][] = {"{default}", "{darkred}", "{green}", "{lightgreen}", "{red}", "{blue}", "{olive}", "{lime}", "{lightred}", "{purple}", "{grey}", "{yellow}", "{orange}", "{bluegrey}", "{lightblue}", "{darkblue}", "{grey2}", "{orchid}", "{lightred2}"};
 char C_TagCode[][] = {"\x01", "\x02", "\x04", "\x03", "\x03", "\x03", "\x05", "\x06", "\x07", "\x03", "\x08", "\x09", "\x10", "\x0A", "\x0B", "\x0C", "\x0D", "\x0E", "\x0F"};
 bool C_TagReqSayText2[] = {false, false, false, true, true, true, false, false, false, false, false, false, false, false, false, false, false, false, false};
-bool C_EventIsHooked = false;
-bool C_SkipList[MAXPLAYERS+1] = {false,...};
+bool C_EventIsHooked;
+bool C_SkipList[MAXPLAYERS+1];
 
 /* Game default profile */
 bool C_Profile_Colors[] = {true, false, true, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false};
 int C_Profile_TeamIndex[] = {NO_INDEX, NO_INDEX, NO_INDEX, NO_INDEX, NO_INDEX, NO_INDEX, NO_INDEX, NO_INDEX, NO_INDEX, NO_INDEX, NO_INDEX, NO_INDEX, NO_INDEX, NO_INDEX, NO_INDEX, NO_INDEX, NO_INDEX, NO_INDEX, NO_INDEX};
-bool C_Profile_SayText2 = false;
+bool C_Profile_SayText2;
 
-static Handle sm_show_activity = null;
+static ConVar sm_show_activity;
 
 /**
  * Prints a message to a specific client in the chat area.
@@ -66,13 +65,14 @@ static Handle sm_show_activity = null;
  * 
  * On error/Errors:   If the client is not connected an error will be thrown.
  */
-stock void C_PrintToChat(int client, const char[] szMessage, any ...)
-{
-	if (client <= 0 || client > MaxClients)
+stock void C_PrintToChat(int client, const char[] szMessage, any ...) {
+	if (client <= 0 || client > MaxClients) {
 		ThrowError("Invalid client index %d", client);
+	}
 
-	if (!IsClientInGame(client))
+	if (!IsClientInGame(client)) {
 		ThrowError("Client %d is not in game", client);
+	}
 
 	char szBuffer[MAX_MESSAGE_LENGTH];
 	char szCMessage[MAX_MESSAGE_LENGTH];
@@ -84,10 +84,12 @@ stock void C_PrintToChat(int client, const char[] szMessage, any ...)
 
 	int index = C_Format(szCMessage, sizeof(szCMessage));
 
-	if (index == NO_INDEX)
+	if (index == NO_INDEX) {
 		PrintToChat(client, "%s", szCMessage);
-	else
+	}
+	else {
 		C_SayText2(client, index, szCMessage);
+	}
 }
 
 /**
@@ -102,24 +104,20 @@ stock void C_PrintToChat(int client, const char[] szMessage, any ...)
  * 
  * On error/Errors:   If the client is not connected or invalid.
  */
-stock void C_ReplyToCommand(int client, const char[] szMessage, any ...)
-{
+stock void C_ReplyToCommand(int client, const char[] szMessage, any ...) {
 	char szCMessage[MAX_MESSAGE_LENGTH];
 	SetGlobalTransTarget(client);
 	VFormat(szCMessage, sizeof(szCMessage), szMessage, 3);
 
-	if (client == 0)
-	{
+	if (client == 0) {
 		C_RemoveTags(szCMessage, sizeof(szCMessage));
 		PrintToServer("%s", szCMessage);
 	}
-	else if (GetCmdReplySource() == SM_REPLY_TO_CONSOLE)
-	{
+	else if (GetCmdReplySource() == SM_REPLY_TO_CONSOLE) {
 		C_RemoveTags(szCMessage, sizeof(szCMessage));
 		PrintToConsole(client, "%s", szCMessage);
 	}
-	else
-	{
+	else {
 		C_PrintToChat(client, "%s", szCMessage);
 	}
 }
@@ -137,24 +135,20 @@ stock void C_ReplyToCommand(int client, const char[] szMessage, any ...)
  * 
  * On error/Errors:   If the client is not connected or invalid.
  */
-stock void C_ReplyToCommandEx(int client, int author, const char[] szMessage, any ...)
-{
+stock void C_ReplyToCommandEx(int client, int author, const char[] szMessage, any ...) {
 	char szCMessage[MAX_MESSAGE_LENGTH];
 	SetGlobalTransTarget(client);
 	VFormat(szCMessage, sizeof(szCMessage), szMessage, 4);
 
-	if (client == 0)
-	{
+	if (client == 0) {
 		C_RemoveTags(szCMessage, sizeof(szCMessage));
 		PrintToServer("%s", szCMessage);
 	}
-	else if (GetCmdReplySource() == SM_REPLY_TO_CONSOLE)
-	{
+	else if (GetCmdReplySource() == SM_REPLY_TO_CONSOLE) {
 		C_RemoveTags(szCMessage, sizeof(szCMessage));
 		PrintToConsole(client, "%s", szCMessage);
 	}
-	else
-	{
+	else {
 		C_PrintToChatEx(client, author, "%s", szCMessage);
 	}
 }
@@ -167,14 +161,11 @@ stock void C_ReplyToCommandEx(int client, int author, const char[] szMessage, an
  * @param szMessage   Message (formatting rules)
  * @return			  No return
  */
-stock void C_PrintToChatAll(const char[] szMessage, any ...)
-{
+stock void C_PrintToChatAll(const char[] szMessage, any ...) {
 	char szBuffer[MAX_MESSAGE_LENGTH];
 
-	MuCo_LoopClients(i)
-	{
-		if (i > 0 && IsClientInGame(i) && !IsFakeClient(i) && !C_SkipList[i])
-		{
+	for (int i = 1; i <= MaxClients; ++i) {
+		if (IsClientInGame(i) && !IsFakeClient(i) && !C_SkipList[i]) {
 			SetGlobalTransTarget(i);
 			VFormat(szBuffer, sizeof(szBuffer), szMessage, 2);
 
@@ -196,16 +187,18 @@ stock void C_PrintToChatAll(const char[] szMessage, any ...)
  * 
  * On error/Errors:   If the client or author are not connected an error will be thrown.
  */
-stock void C_PrintToChatEx(int client, int author, const char[] szMessage, any ...)
-{
-	if (client <= 0 || client > MaxClients)
+stock void C_PrintToChatEx(int client, int author, const char[] szMessage, any ...) {
+	if (client <= 0 || client > MaxClients) {
 		ThrowError("Invalid client index %d", client);
+	}
 
-	if (!IsClientInGame(client))
+	if (!IsClientInGame(client)) {
 		ThrowError("Client %d is not in game", client);
+	}
 
-	if (author < 0 || author > MaxClients)
+	if (author < 0 || author > MaxClients) {
 		ThrowError("Invalid client index %d", author);
+	}
 
 	char szBuffer[MAX_MESSAGE_LENGTH];
 	char szCMessage[MAX_MESSAGE_LENGTH];
@@ -217,10 +210,12 @@ stock void C_PrintToChatEx(int client, int author, const char[] szMessage, any .
 
 	int index = C_Format(szCMessage, sizeof(szCMessage), author);
 
-	if (index == NO_INDEX)
+	if (index == NO_INDEX) {
 		PrintToChat(client, "%s", szCMessage);
-	else
+	}
+	else {
 		C_SayText2(client, author, szCMessage);
+	}
 }
 
 /**
@@ -233,20 +228,19 @@ stock void C_PrintToChatEx(int client, int author, const char[] szMessage, any .
  * 
  * On error/Errors:   If the author is not connected an error will be thrown.
  */
-stock void C_PrintToChatAllEx(int author, const char[] szMessage, any ...)
-{
-	if (author < 0 || author > MaxClients)
+stock void C_PrintToChatAllEx(int author, const char[] szMessage, any ...) {
+	if (author < 0 || author > MaxClients) {
 		ThrowError("Invalid client index %d", author);
+	}
 
-	if (!IsClientInGame(author))
+	if (!IsClientInGame(author)) {
 		ThrowError("Client %d is not in game", author);
+	}
 
 	char szBuffer[MAX_MESSAGE_LENGTH];
 
-	MuCo_LoopClients(i)
-	{
-		if (i > 0 && IsClientInGame(i) && !IsFakeClient(i) && !C_SkipList[i])
-		{
+	for (int i = 1; i <= MaxClients; ++i) {
+		if (IsClientInGame(i) && !IsFakeClient(i) && !C_SkipList[i]) {
 			SetGlobalTransTarget(i);
 			VFormat(szBuffer, sizeof(szBuffer), szMessage, 3);
 
@@ -263,10 +257,10 @@ stock void C_PrintToChatAllEx(int author, const char[] szMessage, any ...)
  * @param szMessage   String.
  * @return			  No return
  */
-stock void C_RemoveTags(char[] szMessage, int maxlength)
-{
-	for (int i = 0; i < MAX_COLORS; i++)
+stock void C_RemoveTags(char[] szMessage, int maxlength) {
+	for (int i = 0; i < MAX_COLORS; i++) {
 		ReplaceString(szMessage, maxlength, C_Tag[i], "", false);
+	}
 
 	ReplaceString(szMessage, maxlength, "{teamcolor}", "", false);
 }
@@ -277,10 +271,8 @@ stock void C_RemoveTags(char[] szMessage, int maxlength)
  * @param tag   		Color Tag.
  * @return			 	True when color is supported, otherwise false
  */
-stock bool C_ColorAllowed(C_Colors color)
-{
-	if (!C_EventIsHooked)
-	{
+stock bool C_ColorAllowed(C_Colors color) {
+	if (!C_EventIsHooked) {
 		C_SetupProfile();
 
 		C_EventIsHooked = true;
@@ -297,10 +289,8 @@ stock bool C_ColorAllowed(C_Colors color)
  * @param newColor   		color to replace with.
  * @noreturn
  */
-stock void C_ReplaceColor(C_Colors color, C_Colors newColor)
-{
-	if (!C_EventIsHooked)
-	{
+stock void C_ReplaceColor(C_Colors color, C_Colors newColor) {
+	if (!C_EventIsHooked) {
 		C_SetupProfile();
 
 		C_EventIsHooked = true;
@@ -323,10 +313,10 @@ stock void C_ReplaceColor(C_Colors color, C_Colors newColor)
  * @param client   Client index
  * @return		   No return
  */
-stock void C_SkipNextClient(int client)
-{
-	if (client <= 0 || client > MaxClients)
+stock void C_SkipNextClient(int client) {
+	if (client <= 0 || client > MaxClients) {
 		ThrowError("Invalid client index %d", client);
+	}
 
 	C_SkipList[client] = true;
 }
@@ -340,11 +330,9 @@ stock void C_SkipNextClient(int client)
  * 
  * On error/Errors:   If there is more then one team color is used an error will be thrown.
  */
-stock int C_Format(char[] szMessage, int maxlength, int author = NO_INDEX)
-{
+stock int C_Format(char[] szMessage, int maxlength, int author = NO_INDEX) {
 	/* Hook event for auto profile setup on map start */
-	if (!C_EventIsHooked)
-	{
+	if (!C_EventIsHooked) {
 		C_SetupProfile();
 		HookEvent("server_spawn", C_Event_MapStart, EventHookMode_PostNoCopy);
 
@@ -354,75 +342,74 @@ stock int C_Format(char[] szMessage, int maxlength, int author = NO_INDEX)
 	int iRandomPlayer = NO_INDEX;
 
 	// On CS:GO set invisible precolor
-	if (GetEngineVersion() == Engine_CSGO) 
-	{
+	if (GetEngineVersion() == Engine_CSGO)  {
 		Format(szMessage, maxlength, " %s", szMessage);
 	}
 
 	/* If author was specified replace {teamcolor} tag */
-	if (author != NO_INDEX)
-	{
-		if (C_Profile_SayText2)
-		{
+	if (author != NO_INDEX) {
+		if (C_Profile_SayText2) {
 			ReplaceString(szMessage, maxlength, "{teamcolor}", "\x03", false);
 
 			iRandomPlayer = author;
 		}
 		/* If saytext2 is not supported by game replace {teamcolor} with green tag  */
-		else
+		else {
 			ReplaceString(szMessage, maxlength, "{teamcolor}", C_TagCode[Color_Green], false);
+		}
 	}
-	else
+	else {
 		ReplaceString(szMessage, maxlength, "{teamcolor}", "", false);
+	}
 
 	/* For other color tags we need a loop */
-	for (int i = 0; i < MAX_COLORS; i++)
-	{
+	for (int i = 0; i < MAX_COLORS; i++) {
 		/* If tag not found - skip */
-		if (StrContains(szMessage, C_Tag[i], false) == -1)
+		if (StrContains(szMessage, C_Tag[i], false) == -1) {
 			continue;
+		}
 
 		/* If tag is not supported by game replace it with green tag */
-		else if (!C_Profile_Colors[i])
+		else if (!C_Profile_Colors[i]) {
 			ReplaceString(szMessage, maxlength, C_Tag[i], C_TagCode[Color_Green], false);
+		}
 
 		/* If tag doesn't need saytext2 simply replace */
-		else if (!C_TagReqSayText2[i])
+		else if (!C_TagReqSayText2[i]) {
 			ReplaceString(szMessage, maxlength, C_Tag[i], C_TagCode[i], false);
+		}
 
 		/* Tag needs saytext2 */
-		else
-		{
+		else {
 			/* If saytext2 is not supported by game replace tag with green tag */
-			if (!C_Profile_SayText2)
+			if (!C_Profile_SayText2) {
 				ReplaceString(szMessage, maxlength, C_Tag[i], C_TagCode[Color_Green], false);
+			}
 
 			/* Game supports saytext2 */
-			else 
-			{
+			else {
 				/* If random player for tag wasn't specified replace tag and find player */
-				if (iRandomPlayer == NO_INDEX)
-				{
+				if (iRandomPlayer == NO_INDEX) {
 					/* Searching for valid client for tag */
 					iRandomPlayer = C_FindRandomPlayerByTeam(C_Profile_TeamIndex[i]);
 
 					/* If player not found replace tag with green color tag */
-					if (iRandomPlayer == NO_PLAYER)
+					if (iRandomPlayer == NO_PLAYER) {
 						ReplaceString(szMessage, maxlength, C_Tag[i], C_TagCode[Color_Green], false);
+					}
 
 					/* If player was found simply replace */
-					else
+					else {
 						ReplaceString(szMessage, maxlength, C_Tag[i], C_TagCode[i], false);
+					}
 
 				}
 				/* If found another team color tag throw error */
-				else
-				{
+				else {
 					//ReplaceString(szMessage, maxlength, C_Tag[i], "");
 					ThrowError("Using two team colors in one message is not allowed");
 				}
 			}
-
 		}
 	}
 
@@ -430,22 +417,27 @@ stock int C_Format(char[] szMessage, int maxlength, int author = NO_INDEX)
 }
 
 /**
- * Founds a random player with specified team
+ * Finds a random player with specified team
  *
  * @param color_team  Client team.
  * @return			  Client index or NO_PLAYER if no player found
  */
-stock int C_FindRandomPlayerByTeam(int color_team)
-{
-	if (color_team == SERVER_INDEX)
+stock int C_FindRandomPlayerByTeam(int color_team) {
+	if (color_team == SERVER_INDEX) {
 		return 0;
-	else
-	{
-		MuCo_LoopClients(i)
-		{
-			if (i > 0 && IsClientInGame(i) && GetClientTeam(i) == color_team)
-				return i;
+	}
+
+	int[] players = new int[MaxClients];
+	int count;
+	
+	for (int i = 1; i <= MaxClients; ++i) {
+		if (IsClientInGame(i) && GetClientTeam(i) == color_team) {
+			players[count++] = i;
 		}
+	}
+
+	if (count) {
+		return players[GetRandomInt(0, count-1)];
 	}
 
 	return NO_PLAYER;
@@ -459,25 +451,24 @@ stock int C_FindRandomPlayerByTeam(int color_team)
  * @param szMessage   Message
  * @return			  No return.
  */
-stock void C_SayText2(int client, int author, const char[] szMessage)
-{
+stock void C_SayText2(int client, int author, const char[] szMessage) {
 	Handle hBuffer = StartMessageOne("SayText2", client, USERMSG_RELIABLE|USERMSG_BLOCKHOOKS);
 
-	if(GetFeatureStatus(FeatureType_Native, "GetUserMessageType") == FeatureStatus_Available && GetUserMessageType() == UM_Protobuf) 
-	{
-		PbSetInt(hBuffer, "ent_idx", author);
-		PbSetBool(hBuffer, "chat", true);
-		PbSetString(hBuffer, "msg_name", szMessage);
-		PbAddString(hBuffer, "params", "");
-		PbAddString(hBuffer, "params", "");
-		PbAddString(hBuffer, "params", "");
-		PbAddString(hBuffer, "params", "");
+	if (GetFeatureStatus(FeatureType_Native, "GetUserMessageType") == FeatureStatus_Available && GetUserMessageType() == UM_Protobuf) {
+		Protobuf pb = UserMessageToProtobuf(hBuffer);
+		pb.SetInt("ent_idx", author);
+		pb.SetBool("chat", true);
+		pb.SetString("msg_name", szMessage);
+		pb.AddString("params", "");
+		pb.AddString("params", "");
+		pb.AddString("params", "");
+		pb.AddString("params", "");
 	}
-	else
-	{
-		BfWriteByte(hBuffer, author);
-		BfWriteByte(hBuffer, true);
-		BfWriteString(hBuffer, szMessage);
+	else {
+		BfWrite bf = UserMessageToBfWrite(hBuffer);
+		bf.WriteByte(author);
+		bf.WriteByte(true);
+		bf.WriteString(szMessage);
 	}
 
 	EndMessage();
@@ -489,12 +480,10 @@ stock void C_SayText2(int client, int author, const char[] szMessage)
  *
  * @return			  No return.
  */
-stock void C_SetupProfile()
-{
+stock void C_SetupProfile() {
 	EngineVersion engine = GetEngineVersion();
 
-	if (engine == Engine_CSS)
-	{
+	if (engine == Engine_CSS) {
 		C_Profile_Colors[Color_Lightgreen] = true;
 		C_Profile_Colors[Color_Red] = true;
 		C_Profile_Colors[Color_Blue] = true;
@@ -504,8 +493,7 @@ stock void C_SetupProfile()
 		C_Profile_TeamIndex[Color_Blue] = 3;
 		C_Profile_SayText2 = true;
 	}
-	else if (engine == Engine_CSGO)
-	{
+	else if (engine == Engine_CSGO) {
 		C_Profile_Colors[Color_Red] = true;
 		C_Profile_Colors[Color_Blue] = true;
 		C_Profile_Colors[Color_Olive] = true;
@@ -526,8 +514,7 @@ stock void C_SetupProfile()
 		C_Profile_TeamIndex[Color_Blue] = 3;
 		C_Profile_SayText2 = true;
 	}
-	else if (engine == Engine_TF2)
-	{
+	else if (engine == Engine_TF2) {
 		C_Profile_Colors[Color_Lightgreen] = true;
 		C_Profile_Colors[Color_Red] = true;
 		C_Profile_Colors[Color_Blue] = true;
@@ -537,8 +524,7 @@ stock void C_SetupProfile()
 		C_Profile_TeamIndex[Color_Blue] = 3;
 		C_Profile_SayText2 = true;
 	}
-	else if (engine == Engine_Left4Dead || engine == Engine_Left4Dead2)
-	{
+	else if (engine == Engine_Left4Dead || engine == Engine_Left4Dead2) {
 		C_Profile_Colors[Color_Lightgreen] = true;
 		C_Profile_Colors[Color_Red] = true;
 		C_Profile_Colors[Color_Blue] = true;
@@ -548,11 +534,9 @@ stock void C_SetupProfile()
 		C_Profile_TeamIndex[Color_Blue] = 2;
 		C_Profile_SayText2 = true;
 	}
-	else if (engine == Engine_HL2DM)
-	{
+	else if (engine == Engine_HL2DM) {
 		/* hl2mp profile is based on mp_teamplay convar */
-		if (GetConVarBool(FindConVar("mp_teamplay")))
-		{
+		if (GetConVarBool(FindConVar("mp_teamplay"))) {
 			C_Profile_Colors[Color_Red] = true;
 			C_Profile_Colors[Color_Blue] = true;
 			C_Profile_Colors[Color_Olive] = true;
@@ -560,26 +544,21 @@ stock void C_SetupProfile()
 			C_Profile_TeamIndex[Color_Blue] = 2;
 			C_Profile_SayText2 = true;
 		}
-		else
-		{
+		else {
 			C_Profile_SayText2 = false;
 			C_Profile_Colors[Color_Olive] = true;
 		}
 	}
-	else if (engine == Engine_DODS)
-	{
+	else if (engine == Engine_DODS) {
 		C_Profile_Colors[Color_Olive] = true;
 		C_Profile_SayText2 = false;
 	}
 	/* Profile for other games */
-	else
-	{
-		if (GetUserMessageId("SayText2") == INVALID_MESSAGE_ID)
-		{
+	else {
+		if (GetUserMessageId("SayText2") == INVALID_MESSAGE_ID) {
 			C_Profile_SayText2 = false;
 		}
-		else
-		{
+		else {
 			C_Profile_Colors[Color_Red] = true;
 			C_Profile_Colors[Color_Blue] = true;
 			C_Profile_TeamIndex[Color_Red] = 2;
@@ -589,12 +568,12 @@ stock void C_SetupProfile()
 	}
 }
 
-public Action C_Event_MapStart(Event event, const char[] name, bool dontBroadcast)
-{
+public Action C_Event_MapStart(Event event, const char[] name, bool dontBroadcast) {
 	C_SetupProfile();
 
-	MuCo_LoopClients(i)
+	for (int i = 1; i <= MaxClients; ++i) {
 		C_SkipList[i] = false;
+	}
 }
 
 /**
@@ -613,37 +592,34 @@ public Action C_Event_MapStart(Event event, const char[] name, bool dontBroadcas
  * @noreturn
  * @error
  */
-stock int C_ShowActivity(int client, const char[] format, any ...)
-{
-	if (sm_show_activity == null)
+stock int C_ShowActivity(int client, const char[] format, any ...) {
+	if (sm_show_activity == null) {
 		sm_show_activity = FindConVar("sm_show_activity");
+	}
 
 	char tag[] = "[SM] ";
 
 	char szBuffer[MAX_MESSAGE_LENGTH];
 	//char szCMessage[MAX_MESSAGE_LENGTH];
-	int  value = GetConVarInt(sm_show_activity);
+	int  value = sm_show_activity.IntValue;
 	ReplySource replyto = GetCmdReplySource();
 
 	char name[MAX_NAME_LENGTH] = "Console";
 	char sign[MAX_NAME_LENGTH] = "ADMIN";
 	bool display_in_chat = false;
-	if (client != 0)
-	{
-		if (client < 0 || client > MaxClients || !IsClientConnected(client))
+	if (client != 0) {
+		if (client < 0 || client > MaxClients || !IsClientConnected(client)) {
 			ThrowError("Client index %d is invalid", client);
+		}
 
 		GetClientName(client, name, sizeof(name));
 		AdminId id = GetUserAdmin(client);
-		if (id == INVALID_ADMIN_ID
-			|| !GetAdminFlag(id, Admin_Generic, Access_Effective))
-		{
+		if (id == INVALID_ADMIN_ID || !GetAdminFlag(id, Admin_Generic, Access_Effective)) {
 			sign = "PLAYER";
 		}
 
 		/* Display the message to the client? */
-		if (replyto == SM_REPLY_TO_CONSOLE)
-		{
+		if (replyto == SM_REPLY_TO_CONSOLE) {
 			SetGlobalTransTarget(client);
 			VFormat(szBuffer, sizeof(szBuffer), format, 3);
 
@@ -652,8 +628,7 @@ stock int C_ShowActivity(int client, const char[] format, any ...)
 			display_in_chat = true;
 		}
 	}
-	else
-	{
+	else {
 		SetGlobalTransTarget(LANG_SERVER);
 		VFormat(szBuffer, sizeof(szBuffer), format, 3);
 
@@ -661,53 +636,47 @@ stock int C_ShowActivity(int client, const char[] format, any ...)
 		PrintToServer("%s%s\n", tag, szBuffer);
 	}
 
-	if (!value)
-	{
+	if (!value) {
 		return 1;
 	}
 
-	MuCo_LoopClients(i)
-	{
-		if (i == 0
-			|| !IsClientInGame(i)
-			|| IsFakeClient(i)
-			|| (display_in_chat && i == client))
-		{
+	for (int i = 1; i <= MaxClients; ++i) {
+		if (!IsClientInGame(i) || IsFakeClient(i) || (display_in_chat && i == client)) {
 			continue;
 		}
+
 		AdminId id = GetUserAdmin(i);
 		SetGlobalTransTarget(i);
-		if (id == INVALID_ADMIN_ID
-			|| !GetAdminFlag(id, Admin_Generic, Access_Effective))
-		{
+		if (id == INVALID_ADMIN_ID || !GetAdminFlag(id, Admin_Generic, Access_Effective)) {
 			/* Treat this as a normal user. */
-			if ((value & 1) | (value & 2))
-			{
+			if ((value & 1) | (value & 2)) {
 				char newsign[MAX_NAME_LENGTH];
-				newsign = sign;
-				if ((value & 2) || (i == client))
-				{
+				
+				if ((value & 2) || (i == client)) {
 					newsign = name;
 				}
+				else {
+					newsign = sign;
+				}
+
 				VFormat(szBuffer, sizeof(szBuffer), format, 3);
 
 				C_PrintToChatEx(i, client, "%s%s: %s", tag, newsign, szBuffer);
 			}
 		}
-		else
-		{
+		else {
 			/* Treat this as an admin user */
 			bool is_root = GetAdminFlag(id, Admin_Root, Access_Effective);
-			if ((value & 4)
-				|| (value & 8)
-				|| ((value & 16) && is_root))
-			{
+			if ((value & 4) || (value & 8) || ((value & 16) && is_root)) {
 				char newsign[MAX_NAME_LENGTH];
-				newsign = sign;
-				if ((value & 8) || ((value & 16) && is_root) || (i == client))
-				{
+				
+				if ((value & 8) || ((value & 16) && is_root) || (i == client)) {
 					newsign = name;
 				}
+				else {
+					newsign = sign;
+				}
+
 				VFormat(szBuffer, sizeof(szBuffer), format, 3);
 
 				C_PrintToChatEx(i, client, "%s%s: %s", tag, newsign, szBuffer);
@@ -729,35 +698,32 @@ stock int C_ShowActivity(int client, const char[] format, any ...)
  * @noreturn
  * @error
  */
-stock int C_ShowActivityEx(int client, const char[] tag, const char[] format, any ...)
-{
-	if (sm_show_activity == null)
+stock int C_ShowActivityEx(int client, const char[] tag, const char[] format, any ...) {
+	if (sm_show_activity == null) {
 		sm_show_activity = FindConVar("sm_show_activity");
+	}
 
 	char szBuffer[MAX_MESSAGE_LENGTH];
 	//char szCMessage[MAX_MESSAGE_LENGTH];
-	int value = GetConVarInt(sm_show_activity);
+	int value = sm_show_activity.IntValue;
 	ReplySource replyto = GetCmdReplySource();
 
 	char name[MAX_NAME_LENGTH] = "Console";
 	char sign[MAX_NAME_LENGTH] = "ADMIN";
 	bool display_in_chat = false;
-	if (client != 0)
-	{
-		if (client < 0 || client > MaxClients || !IsClientConnected(client))
+	if (client != 0) {
+		if (client < 0 || client > MaxClients || !IsClientConnected(client)) {
 			ThrowError("Client index %d is invalid", client);
+		}
 
 		GetClientName(client, name, sizeof(name));
 		AdminId id = GetUserAdmin(client);
-		if (id == INVALID_ADMIN_ID
-			|| !GetAdminFlag(id, Admin_Generic, Access_Effective))
-		{
+		if (id == INVALID_ADMIN_ID || !GetAdminFlag(id, Admin_Generic, Access_Effective)) {
 			sign = "PLAYER";
 		}
 
 		/* Display the message to the client? */
-		if (replyto == SM_REPLY_TO_CONSOLE)
-		{
+		if (replyto == SM_REPLY_TO_CONSOLE) {
 			SetGlobalTransTarget(client);
 			VFormat(szBuffer, sizeof(szBuffer), format, 4);
 
@@ -766,8 +732,7 @@ stock int C_ShowActivityEx(int client, const char[] tag, const char[] format, an
 			display_in_chat = true;
 		}
 	}
-	else
-	{
+	else {
 		SetGlobalTransTarget(LANG_SERVER);
 		VFormat(szBuffer, sizeof(szBuffer), format, 4);
 
@@ -775,53 +740,47 @@ stock int C_ShowActivityEx(int client, const char[] tag, const char[] format, an
 		PrintToServer("%s%s\n", tag, szBuffer);
 	}
 
-	if (!value)
-	{
+	if (!value) {
 		return 1;
 	}
 
-	MuCo_LoopClients(i)
-	{
-		if (i == 0
-			|| !IsClientInGame(i)
-			|| IsFakeClient(i)
-			|| (display_in_chat && i == client))
-		{
+	for (int i = 1; i <= MaxClients; ++i) {
+		if (!IsClientInGame(i) || IsFakeClient(i) || (display_in_chat && i == client)) {
 			continue;
 		}
+
 		AdminId id = GetUserAdmin(i);
 		SetGlobalTransTarget(i);
-		if (id == INVALID_ADMIN_ID
-			|| !GetAdminFlag(id, Admin_Generic, Access_Effective))
-		{
+		if (id == INVALID_ADMIN_ID || !GetAdminFlag(id, Admin_Generic, Access_Effective)) {
 			/* Treat this as a normal user. */
-			if ((value & 1) | (value & 2))
-			{
+			if ((value & 1) | (value & 2)) {
 				char newsign[MAX_NAME_LENGTH];
-				newsign = sign;
-				if ((value & 2) || (i == client))
-				{
+
+				if ((value & 2) || (i == client)) {
 					newsign = name;
 				}
+				else {
+					newsign = sign;
+				}
+
 				VFormat(szBuffer, sizeof(szBuffer), format, 4);
 
 				C_PrintToChatEx(i, client, "%s%s: %s", tag, newsign, szBuffer);
 			}
 		}
-		else
-		{
+		else {
 			/* Treat this as an admin user */
 			bool is_root = GetAdminFlag(id, Admin_Root, Access_Effective);
-			if ((value & 4)
-				|| (value & 8)
-				|| ((value & 16) && is_root))
-			{
+			if ((value & 4) || (value & 8) || ((value & 16) && is_root)) {
 				char newsign[MAX_NAME_LENGTH];
-				newsign = sign;
-				if ((value & 8) || ((value & 16) && is_root) || (i == client))
-				{
+
+				if ((value & 8) || ((value & 16) && is_root) || (i == client)) {
 					newsign = name;
 				}
+				else {
+					newsign = sign;
+				}
+
 				VFormat(szBuffer, sizeof(szBuffer), format, 4);
 
 				C_PrintToChatEx(i, client, "%s%s: %s", tag, newsign, szBuffer);
@@ -845,28 +804,26 @@ stock int C_ShowActivityEx(int client, const char[] tag, const char[] format, an
  * @noreturn
  * @error
  */
-stock int C_ShowActivity2(int client, const char[] tag, const char[] format, any ...)
-{
-	if (sm_show_activity == null)
+stock int C_ShowActivity2(int client, const char[] tag, const char[] format, any ...) {
+	if (sm_show_activity == null) {
 		sm_show_activity = FindConVar("sm_show_activity");
+	}
 
 	char szBuffer[MAX_MESSAGE_LENGTH];
 	//char szCMessage[MAX_MESSAGE_LENGTH];
-	int value = GetConVarInt(sm_show_activity);
+	int value = sm_show_activity.IntValue;
 	// ReplySource replyto = GetCmdReplySource();
 
 	char name[MAX_NAME_LENGTH] = "Console";
 	char sign[MAX_NAME_LENGTH] = "ADMIN";
-	if (client != 0)
-	{
-		if (client < 0 || client > MaxClients || !IsClientConnected(client))
+	if (client != 0) {
+		if (client < 0 || client > MaxClients || !IsClientConnected(client)) {
 			ThrowError("Client index %d is invalid", client);
+		}
 
 		GetClientName(client, name, sizeof(name));
 		AdminId id = GetUserAdmin(client);
-		if (id == INVALID_ADMIN_ID
-		|| !GetAdminFlag(id, Admin_Generic, Access_Effective))
-		{
+		if (id == INVALID_ADMIN_ID || !GetAdminFlag(id, Admin_Generic, Access_Effective)) {
 			sign = "PLAYER";
 		}
 
@@ -879,8 +836,7 @@ stock int C_ShowActivity2(int client, const char[] tag, const char[] format, any
 		 */
 		C_PrintToChatEx(client, client, "%s%s", tag, szBuffer);
 	}
-	else
-	{
+	else {
 		SetGlobalTransTarget(LANG_SERVER);
 		VFormat(szBuffer, sizeof(szBuffer), format, 4);
 
@@ -888,53 +844,48 @@ stock int C_ShowActivity2(int client, const char[] tag, const char[] format, any
 		PrintToServer("%s%s\n", tag, szBuffer);
 	}
 
-	if (!value)
-	{
+	if (!value) {
 		return 1;
 	}
 
-	MuCo_LoopClients(i)
-	{
-		if (i == 0
-			|| !IsClientInGame(i)
-			|| IsFakeClient(i)
-			|| i == client)
-		{
+	for (int i = 1; i <= MaxClients; ++i) {
+		if (!IsClientInGame(i) || IsFakeClient(i) || i == client) {
 			continue;
 		}
+
 		AdminId id = GetUserAdmin(i);
 		SetGlobalTransTarget(i);
 		if (id == INVALID_ADMIN_ID
-		|| !GetAdminFlag(id, Admin_Generic, Access_Effective))
-		{
+		|| !GetAdminFlag(id, Admin_Generic, Access_Effective)) {
 			/* Treat this as a normal user. */
-			if ((value & 1) | (value & 2))
-			{
+			if ((value & 1) | (value & 2)) {
 				char newsign[MAX_NAME_LENGTH];
-				newsign = sign;
-				if ((value & 2))
-				{
+
+				if ((value & 2)) {
 					newsign = name;
 				}
+				else {
+					newsign = sign;
+				}
+
 				VFormat(szBuffer, sizeof(szBuffer), format, 4);
 
 				C_PrintToChatEx(i, client, "%s%s: %s", tag, newsign, szBuffer);
 			}
 		}
-		else
-		{
+		else {
 			/* Treat this as an admin user */
 			bool is_root = GetAdminFlag(id, Admin_Root, Access_Effective);
-			if ((value & 4)
-			|| (value & 8)
-			|| ((value & 16) && is_root))
-			{
+			if ((value & 4) || (value & 8) || ((value & 16) && is_root)) {
 				char newsign[MAX_NAME_LENGTH];
-				newsign = sign;
-				if ((value & 8) || ((value & 16) && is_root))
-				{
+
+				if ((value & 8) || ((value & 16) && is_root)) {
 					newsign = name;
 				}
+				else {
+					newsign = sign;
+				}
+
 				VFormat(szBuffer, sizeof(szBuffer), format, 4);
 
 				C_PrintToChatEx(i, client, "%s%s: %s", tag, newsign, szBuffer);

--- a/addons/sourcemod/scripting/include/multicolors/morecolors.inc
+++ b/addons/sourcemod/scripting/include/multicolors/morecolors.inc
@@ -21,11 +21,11 @@
 
 #define MC_GAME_DODS           0
 
-bool MC_SkipList[MAXPLAYERS + 1];
-Handle MC_Trie;
+bool MC_SkipList[MAXPLAYERS+1];
+StringMap MC_Trie;
 int MC_TeamColors[][] = {{0xCCCCCC, 0x4D7942, 0xFF4040}}; // Multi-dimensional array for games that don't support SayText2. First index is the game index (as defined by the GAME_ defines), second index is team. 0 = spectator, 1 = team1, 2 = team2
 
-static Handle sm_show_activity = INVALID_HANDLE;
+static ConVar sm_show_activity;
 
 /**
  * Prints a message to a specific client in the chat area.
@@ -38,16 +38,22 @@ static Handle sm_show_activity = INVALID_HANDLE;
  */
 stock void MC_PrintToChat(int client, const char[] message, any ...) {
 	MC_CheckTrie();
-	if(client <= 0 || client > MaxClients) {
+
+	if (client <= 0 || client > MaxClients) {
 		ThrowError("Invalid client index %i", client);
 	}
-	if(!IsClientInGame(client)) {
+
+	if (!IsClientInGame(client)) {
 		ThrowError("Client %i is not in game", client);
 	}
-	char buffer[MAX_BUFFER_LENGTH], buffer2[MAX_BUFFER_LENGTH];
+
+	char buffer[MAX_BUFFER_LENGTH];
+	char buffer2[MAX_BUFFER_LENGTH];
+
 	SetGlobalTransTarget(client);
 	Format(buffer, sizeof(buffer), "\x01%s", message);
 	VFormat(buffer2, sizeof(buffer2), buffer, 3);
+
 	MC_ReplaceColorCodes(buffer2);
 	MC_SendMessage(client, buffer2);
 }
@@ -61,15 +67,19 @@ stock void MC_PrintToChat(int client, const char[] message, any ...) {
  */
 stock void MC_PrintToChatAll(const char[] message, any ...) {
 	MC_CheckTrie();
+
 	char buffer[MAX_BUFFER_LENGTH], buffer2[MAX_BUFFER_LENGTH];
-	MuCo_LoopClients(i) {
-		if(i == 0 || !IsClientInGame(i) || MC_SkipList[i]) {
+
+	for (int i = 1; i <= MaxClients; ++i) {
+		if (!IsClientInGame(i) || MC_SkipList[i]) {
 			MC_SkipList[i] = false;
 			continue;
 		}
+
 		SetGlobalTransTarget(i);
 		Format(buffer, sizeof(buffer), "\x01%s", message);
 		VFormat(buffer2, sizeof(buffer2), buffer, 2);
+
 		MC_ReplaceColorCodes(buffer2);
 		MC_SendMessage(i, buffer2);
 	}
@@ -87,18 +97,23 @@ stock void MC_PrintToChatAll(const char[] message, any ...) {
  */
 stock void MC_PrintToChatEx(int client, int author, const char[] message, any ...) {
 	MC_CheckTrie();
-	if(client <= 0 || client > MaxClients) {
+
+	if (client <= 0 || client > MaxClients) {
 		ThrowError("Invalid client index %i", client);
 	}
-	if(!IsClientInGame(client)) {
+
+	if (!IsClientInGame(client)) {
 		ThrowError("Client %i is not in game", client);
 	}
-	if(author <= 0 || author > MaxClients) {
+
+	if (author <= 0 || author > MaxClients) {
 		ThrowError("Invalid client index %i", author);
 	}
-	if(!IsClientInGame(author)) {
+
+	if (!IsClientInGame(author)) {
 		ThrowError("Client %i is not in game", author);
 	}
+
 	char buffer[MAX_BUFFER_LENGTH], buffer2[MAX_BUFFER_LENGTH];
 	SetGlobalTransTarget(client);
 	Format(buffer, sizeof(buffer), "\x01%s", message);
@@ -118,21 +133,28 @@ stock void MC_PrintToChatEx(int client, int author, const char[] message, any ..
  */
 stock void MC_PrintToChatAllEx(int author, const char[] message, any ...) {
 	MC_CheckTrie();
-	if(author <= 0 || author > MaxClients) {
+
+	if (author <= 0 || author > MaxClients) {
 		ThrowError("Invalid client index %i", author);
 	}
-	if(!IsClientInGame(author)) {
+
+	if (!IsClientInGame(author)) {
 		ThrowError("Client %i is not in game", author);
 	}
-	char buffer[MAX_BUFFER_LENGTH], buffer2[MAX_BUFFER_LENGTH];
-	MuCo_LoopClients(i) {
-		if(i == 0 || !IsClientInGame(i) || MC_SkipList[i]) {
+
+	char buffer[MAX_BUFFER_LENGTH];
+	char buffer2[MAX_BUFFER_LENGTH];
+
+	for (int i = 1; i <= MaxClients; ++i) {
+		if (!IsClientInGame(i) || MC_SkipList[i]) {
 			MC_SkipList[i] = false;
 			continue;
 		}
+
 		SetGlobalTransTarget(i);
 		Format(buffer, sizeof(buffer), "\x01%s", message);
 		VFormat(buffer2, sizeof(buffer2), buffer, 3);
+
 		MC_ReplaceColorCodes(buffer2, author);
 		MC_SendMessage(i, buffer2, author);
 	}
@@ -145,40 +167,49 @@ stock void MC_PrintToChatAllEx(int author, const char[] message, any ...) {
  * @param message	Message to send
  */
 stock void MC_SendMessage(int client, const char[] message, int author = 0) {
-	if(author == 0) {
+	if (author == 0) {
 		author = client;
 	}
+
 	char buffer[MC_MAX_MESSAGE_LENGTH];
 	strcopy(buffer, sizeof(buffer), message);
+
 	UserMsg index = GetUserMessageId("SayText2");
-	if(index == INVALID_MESSAGE_ID) {
-		if(GetEngineVersion() == Engine_DODS) {
+	if (index == INVALID_MESSAGE_ID) {
+		if (GetEngineVersion() == Engine_DODS) {
 			int team = GetClientTeam(author);
-			if(team == 0) {
+			if (team == 0) {
 				ReplaceString(buffer, sizeof(buffer), "\x03", "\x04", false); // Unassigned gets green
-			} else {
+			}
+			else {
 				char temp[16];
 				Format(temp, sizeof(temp), "\x07%06X", MC_TeamColors[MC_GAME_DODS][team - 1]);
 				ReplaceString(buffer, sizeof(buffer), "\x03", temp, false);
 			}
 		}
+
 		PrintToChat(client, "%s", buffer);
 		return;
 	}
+
 	Handle buf = StartMessageOne("SayText2", client, USERMSG_RELIABLE|USERMSG_BLOCKHOOKS);
-	if(GetFeatureStatus(FeatureType_Native, "GetUserMessageType") == FeatureStatus_Available && GetUserMessageType() == UM_Protobuf) {
-		PbSetInt(buf, "ent_idx", author);
-		PbSetBool(buf, "chat", true);
-		PbSetString(buf, "msg_name", buffer);
-		PbAddString(buf, "params", "");
-		PbAddString(buf, "params", "");
-		PbAddString(buf, "params", "");
-		PbAddString(buf, "params", "");
-	} else {
-		BfWriteByte(buf, author); // Message author
-		BfWriteByte(buf, true); // Chat message
-		BfWriteString(buf, buffer); // Message text
+	if (GetFeatureStatus(FeatureType_Native, "GetUserMessageType") == FeatureStatus_Available && GetUserMessageType() == UM_Protobuf) {
+		Protobuf pb = UserMessageToProtobuf(buf);
+		pb.SetInt("ent_idx", author);
+		pb.SetBool("chat", true);
+		pb.SetString("msg_name", buffer);
+		pb.AddString("params", "");
+		pb.AddString("params", "");
+		pb.AddString("params", "");
+		pb.AddString("params", "");
 	}
+	else {
+		BfWrite bf = UserMessageToBfWrite(buf);
+		bf.WriteByte(author); // Message author
+		bf.WriteByte(true); // Chat message
+		bf.WriteString(buffer); // Message text
+	}
+
 	EndMessage();
 }
 
@@ -191,9 +222,10 @@ stock void MC_SendMessage(int client, const char[] message, int author = 0) {
  * @param client   Client index
  */
 stock void MC_SkipNextClient(int client) {
-	if(client <= 0 || client > MaxClients) {
+	if (client <= 0 || client > MaxClients) {
 		ThrowError("Invalid client index %i", client);
 	}
+	
 	MC_SkipList[client] = true;
 }
 
@@ -203,7 +235,7 @@ stock void MC_SkipNextClient(int client) {
  * @return			No return
  */
 stock void MC_CheckTrie() {
-	if(MC_Trie == INVALID_HANDLE) {
+	if (MC_Trie == null) {
 		MC_Trie = MC_InitColorTrie();
 	}
 }
@@ -220,21 +252,26 @@ stock void MC_CheckTrie() {
  */
 stock void MC_ReplaceColorCodes(char[] buffer, int author = 0, bool removeTags = false, int maxlen = MAX_BUFFER_LENGTH) {
 	MC_CheckTrie();
-	if(!removeTags) {
+	if (!removeTags) {
 		ReplaceString(buffer, maxlen, "{default}", "\x01", false);
-	} else {
+	}
+	else {
 		ReplaceString(buffer, maxlen, "{default}", "", false);
 		ReplaceString(buffer, maxlen, "{teamcolor}", "", false);
 	}
-	if(author != 0 && !removeTags) {
-		if(author < 0 || author > MaxClients) {
+
+	if (author != 0 && !removeTags) {
+		if (author < 0 || author > MaxClients) {
 			ThrowError("Invalid client index %i", author);
 		}
-		if(!IsClientInGame(author)) {
+
+		if (!IsClientInGame(author)) {
 			ThrowError("Client %i is not in game", author);
 		}
+
 		ReplaceString(buffer, maxlen, "{teamcolor}", "\x03", false);
 	}
+
 	int cursor = 0;
 	int value;
 	char tag[32], buff[32]; 
@@ -243,14 +280,15 @@ stock void MC_ReplaceColorCodes(char[] buffer, int author = 0, bool removeTags =
 	strcopy(output, maxlen, buffer);
 	// Since the string's size is going to be changing, output will hold the replaced string and we'll search buffer
 
-	Handle regex = CompileRegex("{[#a-zA-Z0-9]+}");
-	for(int i = 0; i < 1000; i++) { // The RegEx extension is quite flaky, so we have to loop here :/. This loop is supposed to be infinite and broken by return, but conditions have been added to be safe.
-		if(MatchRegex(regex, buffer[cursor]) < 1) {
-			CloseHandle(regex);
+	Regex regex = new Regex("{[#a-zA-Z0-9]+}");
+	for (int i = 0; i < 1000; i++) { // The RegEx extension is quite flaky, so we have to loop here :/. This loop is supposed to be infinite and broken by return, but conditions have been added to be safe.
+		if (regex.Match(buffer[cursor]) < 1) {
+			delete regex;
 			strcopy(buffer, maxlen, output);
 			return;
 		}
-		GetRegexSubString(regex, 0, tag, sizeof(tag));
+
+		regex.GetSubString(0, tag, sizeof(tag));
 		MC_StrToLower(tag);
 		cursor = StrContains(buffer[cursor], tag, false) + cursor + 1;
 		strcopy(buff, sizeof(buff), tag);
@@ -258,26 +296,31 @@ stock void MC_ReplaceColorCodes(char[] buffer, int author = 0, bool removeTags =
 		ReplaceString(buff, sizeof(buff), "}", "");
 
 		if (buff[0] == '#') {
-			if(strlen(buff) == 7) {
+			if (strlen(buff) == 7) {
 				Format(buff, sizeof(buff), "\x07%s", buff[1]);
-			} else if (strlen(buff) == 9) {
+			}
+			else if (strlen(buff) == 9) {
 				Format(buff, sizeof(buff), "\x08%s", buff[1]);
-			} else {
+			}
+			else {
 				continue;
 			}
 
 			if (removeTags) {
 				ReplaceString(output, maxlen, tag, "", false);
-			} else {
+			}
+			else {
 				ReplaceString(output, maxlen, tag, buff, false);
 			}
-		} else if(!GetTrieValue(MC_Trie, buff, value)) {
+		}
+		else if (!MC_Trie.GetValue(buff, value)) {
 			continue;
 		}
 
-		if(removeTags) {
+		if (removeTags) {
 			ReplaceString(output, maxlen, tag, "", false);
-		} else {
+		}
+		else {
 			Format(buff, sizeof(buff), "\x07%06X", value);
 			ReplaceString(output, maxlen, tag, buff, false);
 		}
@@ -296,11 +339,12 @@ stock void MC_ReplaceColorCodes(char[] buffer, int author = 0, bool removeTags =
  */
 stock void CSubString(const char[] input, char[] output, int maxlen, int start, int numChars = 0) {
 	int i = 0;
-	for(;;) {
-		if(i == maxlen - 1 || i >= numChars || input[start + i] == '\0') {
+	for (;;) {
+		if (i == maxlen - 1 || i >= numChars || input[start + i] == '\0') {
 			output[i] = '\0';
 			return;
 		}
+
 		output[i] = input[start + i];
 		i++;
 	}
@@ -313,7 +357,7 @@ stock void CSubString(const char[] input, char[] output, int maxlen, int start, 
  */
 stock void MC_StrToLower(char[] buffer) {
 	int len = strlen(buffer);
-	for(int i = 0; i < len; i++) {
+	for (int i = 0; i < len; i++) {
 		buffer[i] = CharToLower(buffer[i]);
 	}
 }
@@ -327,14 +371,18 @@ stock void MC_StrToLower(char[] buffer) {
  */
 stock bool MC_AddColor(const char[] name, int color) {
 	MC_CheckTrie();
+
 	int value;
-	if(GetTrieValue(MC_Trie, name, value)) {
+
+	if (MC_Trie.GetValue(name, value)) {
 		return false;
 	}
+
 	char newName[64];
 	strcopy(newName, sizeof(newName), name);
+
 	MC_StrToLower(newName);
-	SetTrieValue(MC_Trie, newName, color);
+	MC_Trie.SetValue(newName, color);
 	return true;
 }
 
@@ -358,13 +406,17 @@ stock void MC_ReplyToCommand(int client, const char[] message, any ...) {
 	char buffer[MAX_BUFFER_LENGTH];
 	SetGlobalTransTarget(client);
 	VFormat(buffer, sizeof(buffer), message, 3);
-	if(client == 0) {
+
+	if (client == 0) {
 		MC_RemoveTags(buffer, sizeof(buffer));
 		PrintToServer("%s", buffer);
-	} if(GetCmdReplySource() == SM_REPLY_TO_CONSOLE) {
+	}
+
+	if (GetCmdReplySource() == SM_REPLY_TO_CONSOLE) {
 		MC_RemoveTags(buffer, sizeof(buffer));
 		PrintToConsole(client, "%s", buffer);
-	} else {
+	}
+	else {
 		MC_PrintToChat(client, "%s", buffer);
 	}
 }
@@ -380,13 +432,17 @@ stock void MC_ReplyToCommandEx(int client, int author, const char[] message, any
 	char buffer[MAX_BUFFER_LENGTH];
 	SetGlobalTransTarget(client);
 	VFormat(buffer, sizeof(buffer), message, 4);
-	if(client == 0) {
+
+	if (client == 0) {
 		MC_RemoveTags(buffer, sizeof(buffer));
 		PrintToServer("%s", buffer);
-	} if(GetCmdReplySource() == SM_REPLY_TO_CONSOLE) {
+	}
+
+	if (GetCmdReplySource() == SM_REPLY_TO_CONSOLE) {
 		MC_RemoveTags(buffer, sizeof(buffer));
 		PrintToConsole(client, "%s", buffer);
-	} else {
+	}
+	else {
 		MC_PrintToChatEx(client, author, "%s", buffer);
 	}
 }
@@ -406,37 +462,33 @@ stock void MC_ReplyToCommandEx(int client, int author, const char[] message, any
  * @param ...			Variable number of format parameters.
  * @error
  */
-stock int MC_ShowActivity(int client, const char[] format, any ...)
-{
-	if (sm_show_activity == INVALID_HANDLE)
+stock int MC_ShowActivity(int client, const char[] format, any ...) {
+	if (sm_show_activity == null) {
 		sm_show_activity = FindConVar("sm_show_activity");
+	}
 
 	char tag[] = "[SM] ";
 
 	char szBuffer[MC_MAX_MESSAGE_LENGTH];
 	//char szCMessage[MC_MAX_MESSAGE_LENGTH];
-	int value = GetConVarInt(sm_show_activity);
+	int value = sm_show_activity.IntValue;
 	ReplySource replyto = GetCmdReplySource();
 
 	char name[MAX_NAME_LENGTH] = "Console";
 	char sign[MAX_NAME_LENGTH] = "ADMIN";
 	bool display_in_chat = false;
-	if (client != 0)
-	{
+	if (client != 0) {
 		if (client < 0 || client > MaxClients || !IsClientConnected(client))
 			ThrowError("Client index %d is invalid", client);
 
 		GetClientName(client, name, sizeof(name));
 		AdminId id = GetUserAdmin(client);
-		if (id == INVALID_ADMIN_ID
-			|| !GetAdminFlag(id, Admin_Generic, Access_Effective))
-		{
+		if (id == INVALID_ADMIN_ID || !id.HasFlag(Admin_Generic, Access_Effective)) {
 			sign = "PLAYER";
 		}
 
 		/* Display the message to the client? */
-		if (replyto == SM_REPLY_TO_CONSOLE)
-		{
+		if (replyto == SM_REPLY_TO_CONSOLE) {
 			SetGlobalTransTarget(client);
 			VFormat(szBuffer, sizeof(szBuffer), format, 3);
 
@@ -445,8 +497,7 @@ stock int MC_ShowActivity(int client, const char[] format, any ...)
 			display_in_chat = true;
 		}
 	}
-	else
-	{
+	else {
 		SetGlobalTransTarget(LANG_SERVER);
 		VFormat(szBuffer, sizeof(szBuffer), format, 3);
 
@@ -454,53 +505,47 @@ stock int MC_ShowActivity(int client, const char[] format, any ...)
 		PrintToServer("%s%s\n", tag, szBuffer);
 	}
 
-	if (!value)
-	{
+	if (!value) {
 		return 1;
 	}
 
-	MuCo_LoopClients(i)
-	{
-		if (i == 0
-			|| !IsClientInGame(i)
-			|| IsFakeClient(i)
-			|| (display_in_chat && i == client))
-		{
+	for (int i = 1; i <= MaxClients; ++i) {
+		if (!IsClientInGame(i) || IsFakeClient(i) || (display_in_chat && i == client)) {
 			continue;
 		}
+
 		AdminId id = GetUserAdmin(i);
 		SetGlobalTransTarget(i);
-		if (id == INVALID_ADMIN_ID
-			|| !GetAdminFlag(id, Admin_Generic, Access_Effective))
-		{
+		if (id == INVALID_ADMIN_ID || !id.HasFlag(Admin_Generic, Access_Effective)) {
 			/* Treat this as a normal user. */
-			if ((value & 1) | (value & 2))
-			{
+			if ((value & 1) | (value & 2)) {
 				char newsign[MAX_NAME_LENGTH];
-				newsign = sign;
-				if ((value & 2) || (i == client))
-				{
+
+				if ((value & 2) || (i == client)) {
 					newsign = name;
 				}
+				else {
+					newsign = sign;
+				}
+
 				VFormat(szBuffer, sizeof(szBuffer), format, 3);
 
 				MC_PrintToChatEx(i, client, "%s%s: %s", tag, newsign, szBuffer);
 			}
 		}
-		else
-		{
+		else {
 			/* Treat this as an admin user */
-			bool is_root = GetAdminFlag(id, Admin_Root, Access_Effective);
-			if ((value & 4)
-				|| (value & 8)
-				|| ((value & 16) && is_root))
-			{
+			bool is_root = id.HasFlag(Admin_Root, Access_Effective);
+			if ((value & 4) || (value & 8) || ((value & 16) && is_root)) {
 				char newsign[MAX_NAME_LENGTH];
-				newsign = sign;
-				if ((value & 8) || ((value & 16) && is_root) || (i == client))
-				{
+
+				if ((value & 8) || ((value & 16) && is_root) || (i == client)) {
 					newsign = name;
 				}
+				else {
+					newsign = sign;
+				}
+
 				VFormat(szBuffer, sizeof(szBuffer), format, 3);
 
 				MC_PrintToChatEx(i, client, "%s%s: %s", tag, newsign, szBuffer);
@@ -521,35 +566,32 @@ stock int MC_ShowActivity(int client, const char[] format, any ...)
  * @param ...			Variable number of format parameters.
  * @error
  */
-stock int MC_ShowActivityEx(int client, const char[] tag, const char[] format, any ...)
-{
-	if (sm_show_activity == INVALID_HANDLE)
+stock int MC_ShowActivityEx(int client, const char[] tag, const char[] format, any ...) {
+	if (sm_show_activity == null) {
 		sm_show_activity = FindConVar("sm_show_activity");
+	}
 
 	char szBuffer[MC_MAX_MESSAGE_LENGTH];
 	//char szCMessage[MC_MAX_MESSAGE_LENGTH];
-	int value = GetConVarInt(sm_show_activity);
+	int value = sm_show_activity.IntValue;
 	ReplySource replyto = GetCmdReplySource();
 
 	char name[MAX_NAME_LENGTH] = "Console";
 	char sign[MAX_NAME_LENGTH] = "ADMIN";
 	bool display_in_chat = false;
-	if (client != 0)
-	{
-		if (client < 0 || client > MaxClients || !IsClientConnected(client))
+	if (client != 0) {
+		if (client < 0 || client > MaxClients || !IsClientConnected(client)) {
 			ThrowError("Client index %d is invalid", client);
+		}
 
 		GetClientName(client, name, sizeof(name));
 		AdminId id = GetUserAdmin(client);
-		if (id == INVALID_ADMIN_ID
-			|| !GetAdminFlag(id, Admin_Generic, Access_Effective))
-		{
+		if (id == INVALID_ADMIN_ID || !id.HasFlag(Admin_Generic, Access_Effective)) {
 			sign = "PLAYER";
 		}
 
 		/* Display the message to the client? */
-		if (replyto == SM_REPLY_TO_CONSOLE)
-		{
+		if (replyto == SM_REPLY_TO_CONSOLE) {
 			SetGlobalTransTarget(client);
 			VFormat(szBuffer, sizeof(szBuffer), format, 4);
 
@@ -558,8 +600,7 @@ stock int MC_ShowActivityEx(int client, const char[] tag, const char[] format, a
 			display_in_chat = true;
 		}
 	}
-	else
-	{
+	else {
 		SetGlobalTransTarget(LANG_SERVER);
 		VFormat(szBuffer, sizeof(szBuffer), format, 4);
 
@@ -567,53 +608,47 @@ stock int MC_ShowActivityEx(int client, const char[] tag, const char[] format, a
 		PrintToServer("%s%s\n", tag, szBuffer);
 	}
 
-	if (!value)
-	{
+	if (!value) {
 		return 1;
 	}
 
-	MuCo_LoopClients(i)
-	{
-		if (i == 0
-			|| !IsClientInGame(i)
-			|| IsFakeClient(i)
-			|| (display_in_chat && i == client))
-		{
+	for (int i = 1; i <= MaxClients; ++i) {
+		if (!IsClientInGame(i) || IsFakeClient(i) || (display_in_chat && i == client)) {
 			continue;
 		}
+
 		AdminId id = GetUserAdmin(i);
 		SetGlobalTransTarget(i);
-		if (id == INVALID_ADMIN_ID
-			|| !GetAdminFlag(id, Admin_Generic, Access_Effective))
-		{
+		if (id == INVALID_ADMIN_ID || !id.HasFlag(Admin_Generic, Access_Effective)) {
 			/* Treat this as a normal user. */
-			if ((value & 1) | (value & 2))
-			{
+			if ((value & 1) | (value & 2)) {
 				char newsign[MAX_NAME_LENGTH];
-				newsign = sign;
-				if ((value & 2) || (i == client))
-				{
+
+				if ((value & 2) || (i == client)) {
 					newsign = name;
 				}
+				else {
+					newsign = sign;
+				}
+
 				VFormat(szBuffer, sizeof(szBuffer), format, 4);
 
 				MC_PrintToChatEx(i, client, "%s%s: %s", tag, newsign, szBuffer);
 			}
 		}
-		else
-		{
+		else {
 			/* Treat this as an admin user */
-			bool is_root = GetAdminFlag(id, Admin_Root, Access_Effective);
-			if ((value & 4)
-				|| (value & 8)
-				|| ((value & 16) && is_root))
-			{
+			bool is_root = id.HasFlag(Admin_Root, Access_Effective);
+			if ((value & 4) || (value & 8) || ((value & 16) && is_root)) {
 				char newsign[MAX_NAME_LENGTH];
-				newsign = sign;
-				if ((value & 8) || ((value & 16) && is_root) || (i == client))
-				{
+
+				if ((value & 8) || ((value & 16) && is_root) || (i == client)) {
 					newsign = name;
 				}
+				else {
+					newsign = sign;
+				}
+
 				VFormat(szBuffer, sizeof(szBuffer), format, 4);
 
 				MC_PrintToChatEx(i, client, "%s%s: %s", tag, newsign, szBuffer);
@@ -636,28 +671,28 @@ stock int MC_ShowActivityEx(int client, const char[] tag, const char[] format, a
  * @param ...			Variable number of format parameters.
  * @error
  */
-stock int MC_ShowActivity2(int client, const char[] tag, const char[] format, any ...)
-{
-	if (sm_show_activity == INVALID_HANDLE)
+stock int MC_ShowActivity2(int client, const char[] tag, const char[] format, any ...) {
+	if (sm_show_activity == null) {
 		sm_show_activity = FindConVar("sm_show_activity");
+	}
 
 	char szBuffer[MC_MAX_MESSAGE_LENGTH];
 	//char szCMessage[MC_MAX_MESSAGE_LENGTH];
-	int value = GetConVarInt(sm_show_activity);
+	int value = sm_show_activity.IntValue;
 	// ReplySource replyto = GetCmdReplySource();
 
 	char name[MAX_NAME_LENGTH] = "Console";
 	char sign[MAX_NAME_LENGTH] = "ADMIN";
-	if (client != 0)
-	{
-		if (client < 0 || client > MaxClients || !IsClientConnected(client))
+
+	if (client != 0) {
+		if (client < 0 || client > MaxClients || !IsClientConnected(client)) {
 			ThrowError("Client index %d is invalid", client);
+		}
 
 		GetClientName(client, name, sizeof(name));
+
 		AdminId id = GetUserAdmin(client);
-		if (id == INVALID_ADMIN_ID
-		|| !GetAdminFlag(id, Admin_Generic, Access_Effective))
-		{
+		if (id == INVALID_ADMIN_ID || !id.HasFlag(Admin_Generic, Access_Effective)) {
 			sign = "PLAYER";
 		}
 
@@ -670,8 +705,7 @@ stock int MC_ShowActivity2(int client, const char[] tag, const char[] format, an
 		 */
 		MC_PrintToChatEx(client, client, "%s%s", tag, szBuffer);
 	}
-	else
-	{
+	else {
 		SetGlobalTransTarget(LANG_SERVER);
 		VFormat(szBuffer, sizeof(szBuffer), format, 4);
 
@@ -679,53 +713,48 @@ stock int MC_ShowActivity2(int client, const char[] tag, const char[] format, an
 		PrintToServer("%s%s\n", tag, szBuffer);
 	}
 
-	if (!value)
-	{
+	if (!value) {
 		return 1;
 	}
 
-	MuCo_LoopClients(i)
-	{
-		if (i == 0
-			|| !IsClientInGame(i)
-			|| IsFakeClient(i)
-			|| i == client)
-		{
+	for (int i = 1; i <= MaxClients; ++i) {
+		if (!IsClientInGame(i) || IsFakeClient(i) || i == client) {
 			continue;
 		}
+
 		AdminId id = GetUserAdmin(i);
 		SetGlobalTransTarget(i);
-		if (id == INVALID_ADMIN_ID
-		|| !GetAdminFlag(id, Admin_Generic, Access_Effective))
-		{
+		if (id == INVALID_ADMIN_ID || !id.HasFlag(Admin_Generic, Access_Effective)) {
 			/* Treat this as a normal user. */
-			if ((value & 1) | (value & 2))
-			{
+			if ((value & 1) | (value & 2)) {
 				char newsign[MAX_NAME_LENGTH];
-				newsign = sign;
-				if ((value & 2))
-				{
+
+				if ((value & 2)) {
 					newsign = name;
 				}
+				else {
+					newsign = sign;
+				}
+
 				VFormat(szBuffer, sizeof(szBuffer), format, 4);
 
 				MC_PrintToChatEx(i, client, "%s%s: %s", tag, newsign, szBuffer);
 			}
 		}
-		else
-		{
+		else {
 			/* Treat this as an admin user */
-			bool is_root = GetAdminFlag(id, Admin_Root, Access_Effective);
-			if ((value & 4)
-			|| (value & 8)
-			|| ((value & 16) && is_root))
-			{
+			bool is_root = id.HasFlag(Admin_Root, Access_Effective);
+			if ((value & 4) || (value & 8) || ((value & 16) && is_root)) {
 				char newsign[MAX_NAME_LENGTH];
-				newsign = sign;
-				if ((value & 8) || ((value & 16) && is_root))
-				{
+				
+
+				if ((value & 8) || ((value & 16) && is_root)) {
 					newsign = name;
 				}
+				else {
+					newsign = sign;
+				}
+
 				VFormat(szBuffer, sizeof(szBuffer), format, 4);
 
 				MC_PrintToChatEx(i, client, "%s%s: %s", tag, newsign, szBuffer);
@@ -745,7 +774,7 @@ stock int MC_ShowActivity2(int client, const char[] tag, const char[] format, an
 stock bool CColorExists(const char[] color) {
 	MC_CheckTrie();
 	int temp;
-	return GetTrieValue(MC_Trie, color, temp);
+	return MC_Trie.GetValue(color, temp);
 }
 
 /**
@@ -756,12 +785,14 @@ stock bool CColorExists(const char[] color) {
  * On error/Errors:		If the client index passed is invalid or not in game.
  */
 stock int CGetTeamColor(int client) {
-	if(client <= 0 || client > MaxClients) {
+	if (client <= 0 || client > MaxClients) {
 		ThrowError("Invalid client index %i", client);
 	}
-	if(!IsClientInGame(client)) {
+
+	if (!IsClientInGame(client)) {
 		ThrowError("Client %i is not in game", client);
 	}
+
 	int value;
 	switch(GetClientTeam(client)) {
 		case 1: {
@@ -777,183 +808,185 @@ stock int CGetTeamColor(int client) {
 			value = MCOLOR_GREEN;
 		}
 	}
+
 	return value;
 }
 
-stock Handle MC_InitColorTrie() {
-	Handle hTrie = CreateTrie();
-	SetTrieValue(hTrie, "aliceblue", 0xF0F8FF);
-	SetTrieValue(hTrie, "allies", 0x4D7942); // same as Allies team in DoD:S
-	SetTrieValue(hTrie, "ancient", 0xEB4B4B); // same as Ancient item rarity in Dota 2
-	SetTrieValue(hTrie, "antiquewhite", 0xFAEBD7);
-	SetTrieValue(hTrie, "aqua", 0x00FFFF);
-	SetTrieValue(hTrie, "aquamarine", 0x7FFFD4);
-	SetTrieValue(hTrie, "arcana", 0xADE55C); // same as Arcana item rarity in Dota 2
-	SetTrieValue(hTrie, "axis", 0xFF4040); // same as Axis team in DoD:S
-	SetTrieValue(hTrie, "azure", 0x007FFF);
-	SetTrieValue(hTrie, "beige", 0xF5F5DC);
-	SetTrieValue(hTrie, "bisque", 0xFFE4C4);
-	SetTrieValue(hTrie, "black", 0x000000);
-	SetTrieValue(hTrie, "blanchedalmond", 0xFFEBCD);
-	SetTrieValue(hTrie, "blue", 0x99CCFF); // same as BLU/Counter-Terrorist team color
-	SetTrieValue(hTrie, "blueviolet", 0x8A2BE2);
-	SetTrieValue(hTrie, "brown", 0xA52A2A);
-	SetTrieValue(hTrie, "burlywood", 0xDEB887);
-	SetTrieValue(hTrie, "cadetblue", 0x5F9EA0);
-	SetTrieValue(hTrie, "chartreuse", 0x7FFF00);
-	SetTrieValue(hTrie, "chocolate", 0xD2691E);
-	SetTrieValue(hTrie, "collectors", 0xAA0000); // same as Collector's item quality in TF2
-	SetTrieValue(hTrie, "common", 0xB0C3D9); // same as Common item rarity in Dota 2
-	SetTrieValue(hTrie, "community", 0x70B04A); // same as Community item quality in TF2
-	SetTrieValue(hTrie, "coral", 0xFF7F50);
-	SetTrieValue(hTrie, "cornflowerblue", 0x6495ED);
-	SetTrieValue(hTrie, "cornsilk", 0xFFF8DC);
-	SetTrieValue(hTrie, "corrupted", 0xA32C2E); // same as Corrupted item quality in Dota 2
-	SetTrieValue(hTrie, "crimson", 0xDC143C);
-	SetTrieValue(hTrie, "cyan", 0x00FFFF);
-	SetTrieValue(hTrie, "darkblue", 0x00008B);
-	SetTrieValue(hTrie, "darkcyan", 0x008B8B);
-	SetTrieValue(hTrie, "darkgoldenrod", 0xB8860B);
-	SetTrieValue(hTrie, "darkgray", 0xA9A9A9);
-	SetTrieValue(hTrie, "darkgrey", 0xA9A9A9);
-	SetTrieValue(hTrie, "darkgreen", 0x006400);
-	SetTrieValue(hTrie, "darkkhaki", 0xBDB76B);
-	SetTrieValue(hTrie, "darkmagenta", 0x8B008B);
-	SetTrieValue(hTrie, "darkolivegreen", 0x556B2F);
-	SetTrieValue(hTrie, "darkorange", 0xFF8C00);
-	SetTrieValue(hTrie, "darkorchid", 0x9932CC);
-	SetTrieValue(hTrie, "darkred", 0x8B0000);
-	SetTrieValue(hTrie, "darksalmon", 0xE9967A);
-	SetTrieValue(hTrie, "darkseagreen", 0x8FBC8F);
-	SetTrieValue(hTrie, "darkslateblue", 0x483D8B);
-	SetTrieValue(hTrie, "darkslategray", 0x2F4F4F);
-	SetTrieValue(hTrie, "darkslategrey", 0x2F4F4F);
-	SetTrieValue(hTrie, "darkturquoise", 0x00CED1);
-	SetTrieValue(hTrie, "darkviolet", 0x9400D3);
-	SetTrieValue(hTrie, "deeppink", 0xFF1493);
-	SetTrieValue(hTrie, "deepskyblue", 0x00BFFF);
-	SetTrieValue(hTrie, "dimgray", 0x696969);
-	SetTrieValue(hTrie, "dimgrey", 0x696969);
-	SetTrieValue(hTrie, "dodgerblue", 0x1E90FF);
-	SetTrieValue(hTrie, "exalted", 0xCCCCCD); // same as Exalted item quality in Dota 2
-	SetTrieValue(hTrie, "firebrick", 0xB22222);
-	SetTrieValue(hTrie, "floralwhite", 0xFFFAF0);
-	SetTrieValue(hTrie, "forestgreen", 0x228B22);
-	SetTrieValue(hTrie, "frozen", 0x4983B3); // same as Frozen item quality in Dota 2
-	SetTrieValue(hTrie, "fuchsia", 0xFF00FF);
-	SetTrieValue(hTrie, "fullblue", 0x0000FF);
-	SetTrieValue(hTrie, "fullred", 0xFF0000);
-	SetTrieValue(hTrie, "gainsboro", 0xDCDCDC);
-	SetTrieValue(hTrie, "genuine", 0x4D7455); // same as Genuine item quality in TF2
-	SetTrieValue(hTrie, "ghostwhite", 0xF8F8FF);
-	SetTrieValue(hTrie, "gold", 0xFFD700);
-	SetTrieValue(hTrie, "goldenrod", 0xDAA520);
-	SetTrieValue(hTrie, "gray", 0xCCCCCC); // same as spectator team color
-	SetTrieValue(hTrie, "grey", 0xCCCCCC);
-	SetTrieValue(hTrie, "green", 0x3EFF3E);
-	SetTrieValue(hTrie, "greenyellow", 0xADFF2F);
-	SetTrieValue(hTrie, "haunted", 0x38F3AB); // same as Haunted item quality in TF2
-	SetTrieValue(hTrie, "honeydew", 0xF0FFF0);
-	SetTrieValue(hTrie, "hotpink", 0xFF69B4);
-	SetTrieValue(hTrie, "immortal", 0xE4AE33); // same as Immortal item rarity in Dota 2
-	SetTrieValue(hTrie, "indianred", 0xCD5C5C);
-	SetTrieValue(hTrie, "indigo", 0x4B0082);
-	SetTrieValue(hTrie, "ivory", 0xFFFFF0);
-	SetTrieValue(hTrie, "khaki", 0xF0E68C);
-	SetTrieValue(hTrie, "lavender", 0xE6E6FA);
-	SetTrieValue(hTrie, "lavenderblush", 0xFFF0F5);
-	SetTrieValue(hTrie, "lawngreen", 0x7CFC00);
-	SetTrieValue(hTrie, "legendary", 0xD32CE6); // same as Legendary item rarity in Dota 2
-	SetTrieValue(hTrie, "lemonchiffon", 0xFFFACD);
-	SetTrieValue(hTrie, "lightblue", 0xADD8E6);
-	SetTrieValue(hTrie, "lightcoral", 0xF08080);
-	SetTrieValue(hTrie, "lightcyan", 0xE0FFFF);
-	SetTrieValue(hTrie, "lightgoldenrodyellow", 0xFAFAD2);
-	SetTrieValue(hTrie, "lightgray", 0xD3D3D3);
-	SetTrieValue(hTrie, "lightgrey", 0xD3D3D3);
-	SetTrieValue(hTrie, "lightgreen", 0x99FF99);
-	SetTrieValue(hTrie, "lightpink", 0xFFB6C1);
-	SetTrieValue(hTrie, "lightsalmon", 0xFFA07A);
-	SetTrieValue(hTrie, "lightseagreen", 0x20B2AA);
-	SetTrieValue(hTrie, "lightskyblue", 0x87CEFA);
-	SetTrieValue(hTrie, "lightslategray", 0x778899);
-	SetTrieValue(hTrie, "lightslategrey", 0x778899);
-	SetTrieValue(hTrie, "lightsteelblue", 0xB0C4DE);
-	SetTrieValue(hTrie, "lightyellow", 0xFFFFE0);
-	SetTrieValue(hTrie, "lime", 0x00FF00);
-	SetTrieValue(hTrie, "limegreen", 0x32CD32);
-	SetTrieValue(hTrie, "linen", 0xFAF0E6);
-	SetTrieValue(hTrie, "magenta", 0xFF00FF);
-	SetTrieValue(hTrie, "maroon", 0x800000);
-	SetTrieValue(hTrie, "mediumaquamarine", 0x66CDAA);
-	SetTrieValue(hTrie, "mediumblue", 0x0000CD);
-	SetTrieValue(hTrie, "mediumorchid", 0xBA55D3);
-	SetTrieValue(hTrie, "mediumpurple", 0x9370D8);
-	SetTrieValue(hTrie, "mediumseagreen", 0x3CB371);
-	SetTrieValue(hTrie, "mediumslateblue", 0x7B68EE);
-	SetTrieValue(hTrie, "mediumspringgreen", 0x00FA9A);
-	SetTrieValue(hTrie, "mediumturquoise", 0x48D1CC);
-	SetTrieValue(hTrie, "mediumvioletred", 0xC71585);
-	SetTrieValue(hTrie, "midnightblue", 0x191970);
-	SetTrieValue(hTrie, "mintcream", 0xF5FFFA);
-	SetTrieValue(hTrie, "mistyrose", 0xFFE4E1);
-	SetTrieValue(hTrie, "moccasin", 0xFFE4B5);
-	SetTrieValue(hTrie, "mythical", 0x8847FF); // same as Mythical item rarity in Dota 2
-	SetTrieValue(hTrie, "navajowhite", 0xFFDEAD);
-	SetTrieValue(hTrie, "navy", 0x000080);
-	SetTrieValue(hTrie, "normal", 0xB2B2B2); // same as Normal item quality in TF2
-	SetTrieValue(hTrie, "oldlace", 0xFDF5E6);
-	SetTrieValue(hTrie, "olive", 0x9EC34F);
-	SetTrieValue(hTrie, "olivedrab", 0x6B8E23);
-	SetTrieValue(hTrie, "orange", 0xFFA500);
-	SetTrieValue(hTrie, "orangered", 0xFF4500);
-	SetTrieValue(hTrie, "orchid", 0xDA70D6);
-	SetTrieValue(hTrie, "palegoldenrod", 0xEEE8AA);
-	SetTrieValue(hTrie, "palegreen", 0x98FB98);
-	SetTrieValue(hTrie, "paleturquoise", 0xAFEEEE);
-	SetTrieValue(hTrie, "palevioletred", 0xD87093);
-	SetTrieValue(hTrie, "papayawhip", 0xFFEFD5);
-	SetTrieValue(hTrie, "peachpuff", 0xFFDAB9);
-	SetTrieValue(hTrie, "peru", 0xCD853F);
-	SetTrieValue(hTrie, "pink", 0xFFC0CB);
-	SetTrieValue(hTrie, "plum", 0xDDA0DD);
-	SetTrieValue(hTrie, "powderblue", 0xB0E0E6);
-	SetTrieValue(hTrie, "purple", 0x800080);
-	SetTrieValue(hTrie, "rare", 0x4B69FF); // same as Rare item rarity in Dota 2
-	SetTrieValue(hTrie, "red", 0xFF4040); // same as RED/Terrorist team color
-	SetTrieValue(hTrie, "rosybrown", 0xBC8F8F);
-	SetTrieValue(hTrie, "royalblue", 0x4169E1);
-	SetTrieValue(hTrie, "saddlebrown", 0x8B4513);
-	SetTrieValue(hTrie, "salmon", 0xFA8072);
-	SetTrieValue(hTrie, "sandybrown", 0xF4A460);
-	SetTrieValue(hTrie, "seagreen", 0x2E8B57);
-	SetTrieValue(hTrie, "seashell", 0xFFF5EE);
-	SetTrieValue(hTrie, "selfmade", 0x70B04A); // same as Self-Made item quality in TF2
-	SetTrieValue(hTrie, "sienna", 0xA0522D);
-	SetTrieValue(hTrie, "silver", 0xC0C0C0);
-	SetTrieValue(hTrie, "skyblue", 0x87CEEB);
-	SetTrieValue(hTrie, "slateblue", 0x6A5ACD);
-	SetTrieValue(hTrie, "slategray", 0x708090);
-	SetTrieValue(hTrie, "slategrey", 0x708090);
-	SetTrieValue(hTrie, "snow", 0xFFFAFA);
-	SetTrieValue(hTrie, "springgreen", 0x00FF7F);
-	SetTrieValue(hTrie, "steelblue", 0x4682B4);
-	SetTrieValue(hTrie, "strange", 0xCF6A32); // same as Strange item quality in TF2
-	SetTrieValue(hTrie, "tan", 0xD2B48C);
-	SetTrieValue(hTrie, "teal", 0x008080);
-	SetTrieValue(hTrie, "thistle", 0xD8BFD8);
-	SetTrieValue(hTrie, "tomato", 0xFF6347);
-	SetTrieValue(hTrie, "turquoise", 0x40E0D0);
-	SetTrieValue(hTrie, "uncommon", 0xB0C3D9); // same as Uncommon item rarity in Dota 2
-	SetTrieValue(hTrie, "unique", 0xFFD700); // same as Unique item quality in TF2
-	SetTrieValue(hTrie, "unusual", 0x8650AC); // same as Unusual item quality in TF2
-	SetTrieValue(hTrie, "valve", 0xA50F79); // same as Valve item quality in TF2
-	SetTrieValue(hTrie, "vintage", 0x476291); // same as Vintage item quality in TF2
-	SetTrieValue(hTrie, "violet", 0xEE82EE);
-	SetTrieValue(hTrie, "wheat", 0xF5DEB3);
-	SetTrieValue(hTrie, "white", 0xFFFFFF);
-	SetTrieValue(hTrie, "whitesmoke", 0xF5F5F5);
-	SetTrieValue(hTrie, "yellow", 0xFFFF00);
-	SetTrieValue(hTrie, "yellowgreen", 0x9ACD32);
+stock StringMap MC_InitColorTrie() {
+	StringMap hTrie = new StringMap();
+	hTrie.SetValue("aliceblue", 0xF0F8FF);
+	hTrie.SetValue("allies", 0x4D7942); // same as Allies team in DoD:S
+	hTrie.SetValue("ancient", 0xEB4B4B); // same as Ancient item rarity in Dota 2
+	hTrie.SetValue("antiquewhite", 0xFAEBD7);
+	hTrie.SetValue("aqua", 0x00FFFF);
+	hTrie.SetValue("aquamarine", 0x7FFFD4);
+	hTrie.SetValue("arcana", 0xADE55C); // same as Arcana item rarity in Dota 2
+	hTrie.SetValue("axis", 0xFF4040); // same as Axis team in DoD:S
+	hTrie.SetValue("azure", 0x007FFF);
+	hTrie.SetValue("beige", 0xF5F5DC);
+	hTrie.SetValue("bisque", 0xFFE4C4);
+	hTrie.SetValue("black", 0x000000);
+	hTrie.SetValue("blanchedalmond", 0xFFEBCD);
+	hTrie.SetValue("blue", 0x99CCFF); // same as BLU/Counter-Terrorist team color
+	hTrie.SetValue("blueviolet", 0x8A2BE2);
+	hTrie.SetValue("brown", 0xA52A2A);
+	hTrie.SetValue("burlywood", 0xDEB887);
+	hTrie.SetValue("cadetblue", 0x5F9EA0);
+	hTrie.SetValue("chartreuse", 0x7FFF00);
+	hTrie.SetValue("chocolate", 0xD2691E);
+	hTrie.SetValue("collectors", 0xAA0000); // same as Collector's item quality in TF2
+	hTrie.SetValue("common", 0xB0C3D9); // same as Common item rarity in Dota 2
+	hTrie.SetValue("community", 0x70B04A); // same as Community item quality in TF2
+	hTrie.SetValue("coral", 0xFF7F50);
+	hTrie.SetValue("cornflowerblue", 0x6495ED);
+	hTrie.SetValue("cornsilk", 0xFFF8DC);
+	hTrie.SetValue("corrupted", 0xA32C2E); // same as Corrupted item quality in Dota 2
+	hTrie.SetValue("crimson", 0xDC143C);
+	hTrie.SetValue("cyan", 0x00FFFF);
+	hTrie.SetValue("darkblue", 0x00008B);
+	hTrie.SetValue("darkcyan", 0x008B8B);
+	hTrie.SetValue("darkgoldenrod", 0xB8860B);
+	hTrie.SetValue("darkgray", 0xA9A9A9);
+	hTrie.SetValue("darkgrey", 0xA9A9A9);
+	hTrie.SetValue("darkgreen", 0x006400);
+	hTrie.SetValue("darkkhaki", 0xBDB76B);
+	hTrie.SetValue("darkmagenta", 0x8B008B);
+	hTrie.SetValue("darkolivegreen", 0x556B2F);
+	hTrie.SetValue("darkorange", 0xFF8C00);
+	hTrie.SetValue("darkorchid", 0x9932CC);
+	hTrie.SetValue("darkred", 0x8B0000);
+	hTrie.SetValue("darksalmon", 0xE9967A);
+	hTrie.SetValue("darkseagreen", 0x8FBC8F);
+	hTrie.SetValue("darkslateblue", 0x483D8B);
+	hTrie.SetValue("darkslategray", 0x2F4F4F);
+	hTrie.SetValue("darkslategrey", 0x2F4F4F);
+	hTrie.SetValue("darkturquoise", 0x00CED1);
+	hTrie.SetValue("darkviolet", 0x9400D3);
+	hTrie.SetValue("deeppink", 0xFF1493);
+	hTrie.SetValue("deepskyblue", 0x00BFFF);
+	hTrie.SetValue("dimgray", 0x696969);
+	hTrie.SetValue("dimgrey", 0x696969);
+	hTrie.SetValue("dodgerblue", 0x1E90FF);
+	hTrie.SetValue("exalted", 0xCCCCCD); // same as Exalted item quality in Dota 2
+	hTrie.SetValue("firebrick", 0xB22222);
+	hTrie.SetValue("floralwhite", 0xFFFAF0);
+	hTrie.SetValue("forestgreen", 0x228B22);
+	hTrie.SetValue("frozen", 0x4983B3); // same as Frozen item quality in Dota 2
+	hTrie.SetValue("fuchsia", 0xFF00FF);
+	hTrie.SetValue("fullblue", 0x0000FF);
+	hTrie.SetValue("fullred", 0xFF0000);
+	hTrie.SetValue("gainsboro", 0xDCDCDC);
+	hTrie.SetValue("genuine", 0x4D7455); // same as Genuine item quality in TF2
+	hTrie.SetValue("ghostwhite", 0xF8F8FF);
+	hTrie.SetValue("gold", 0xFFD700);
+	hTrie.SetValue("goldenrod", 0xDAA520);
+	hTrie.SetValue("gray", 0xCCCCCC); // same as spectator team color
+	hTrie.SetValue("grey", 0xCCCCCC);
+	hTrie.SetValue("green", 0x3EFF3E);
+	hTrie.SetValue("greenyellow", 0xADFF2F);
+	hTrie.SetValue("haunted", 0x38F3AB); // same as Haunted item quality in TF2
+	hTrie.SetValue("honeydew", 0xF0FFF0);
+	hTrie.SetValue("hotpink", 0xFF69B4);
+	hTrie.SetValue("immortal", 0xE4AE33); // same as Immortal item rarity in Dota 2
+	hTrie.SetValue("indianred", 0xCD5C5C);
+	hTrie.SetValue("indigo", 0x4B0082);
+	hTrie.SetValue("ivory", 0xFFFFF0);
+	hTrie.SetValue("khaki", 0xF0E68C);
+	hTrie.SetValue("lavender", 0xE6E6FA);
+	hTrie.SetValue("lavenderblush", 0xFFF0F5);
+	hTrie.SetValue("lawngreen", 0x7CFC00);
+	hTrie.SetValue("legendary", 0xD32CE6); // same as Legendary item rarity in Dota 2
+	hTrie.SetValue("lemonchiffon", 0xFFFACD);
+	hTrie.SetValue("lightblue", 0xADD8E6);
+	hTrie.SetValue("lightcoral", 0xF08080);
+	hTrie.SetValue("lightcyan", 0xE0FFFF);
+	hTrie.SetValue("lightgoldenrodyellow", 0xFAFAD2);
+	hTrie.SetValue("lightgray", 0xD3D3D3);
+	hTrie.SetValue("lightgrey", 0xD3D3D3);
+	hTrie.SetValue("lightgreen", 0x99FF99);
+	hTrie.SetValue("lightpink", 0xFFB6C1);
+	hTrie.SetValue("lightsalmon", 0xFFA07A);
+	hTrie.SetValue("lightseagreen", 0x20B2AA);
+	hTrie.SetValue("lightskyblue", 0x87CEFA);
+	hTrie.SetValue("lightslategray", 0x778899);
+	hTrie.SetValue("lightslategrey", 0x778899);
+	hTrie.SetValue("lightsteelblue", 0xB0C4DE);
+	hTrie.SetValue("lightyellow", 0xFFFFE0);
+	hTrie.SetValue("lime", 0x00FF00);
+	hTrie.SetValue("limegreen", 0x32CD32);
+	hTrie.SetValue("linen", 0xFAF0E6);
+	hTrie.SetValue("magenta", 0xFF00FF);
+	hTrie.SetValue("maroon", 0x800000);
+	hTrie.SetValue("mediumaquamarine", 0x66CDAA);
+	hTrie.SetValue("mediumblue", 0x0000CD);
+	hTrie.SetValue("mediumorchid", 0xBA55D3);
+	hTrie.SetValue("mediumpurple", 0x9370D8);
+	hTrie.SetValue("mediumseagreen", 0x3CB371);
+	hTrie.SetValue("mediumslateblue", 0x7B68EE);
+	hTrie.SetValue("mediumspringgreen", 0x00FA9A);
+	hTrie.SetValue("mediumturquoise", 0x48D1CC);
+	hTrie.SetValue("mediumvioletred", 0xC71585);
+	hTrie.SetValue("midnightblue", 0x191970);
+	hTrie.SetValue("mintcream", 0xF5FFFA);
+	hTrie.SetValue("mistyrose", 0xFFE4E1);
+	hTrie.SetValue("moccasin", 0xFFE4B5);
+	hTrie.SetValue("mythical", 0x8847FF); // same as Mythical item rarity in Dota 2
+	hTrie.SetValue("navajowhite", 0xFFDEAD);
+	hTrie.SetValue("navy", 0x000080);
+	hTrie.SetValue("normal", 0xB2B2B2); // same as Normal item quality in TF2
+	hTrie.SetValue("oldlace", 0xFDF5E6);
+	hTrie.SetValue("olive", 0x9EC34F);
+	hTrie.SetValue("olivedrab", 0x6B8E23);
+	hTrie.SetValue("orange", 0xFFA500);
+	hTrie.SetValue("orangered", 0xFF4500);
+	hTrie.SetValue("orchid", 0xDA70D6);
+	hTrie.SetValue("palegoldenrod", 0xEEE8AA);
+	hTrie.SetValue("palegreen", 0x98FB98);
+	hTrie.SetValue("paleturquoise", 0xAFEEEE);
+	hTrie.SetValue("palevioletred", 0xD87093);
+	hTrie.SetValue("papayawhip", 0xFFEFD5);
+	hTrie.SetValue("peachpuff", 0xFFDAB9);
+	hTrie.SetValue("peru", 0xCD853F);
+	hTrie.SetValue("pink", 0xFFC0CB);
+	hTrie.SetValue("plum", 0xDDA0DD);
+	hTrie.SetValue("powderblue", 0xB0E0E6);
+	hTrie.SetValue("purple", 0x800080);
+	hTrie.SetValue("rare", 0x4B69FF); // same as Rare item rarity in Dota 2
+	hTrie.SetValue("red", 0xFF4040); // same as RED/Terrorist team color
+	hTrie.SetValue("rosybrown", 0xBC8F8F);
+	hTrie.SetValue("royalblue", 0x4169E1);
+	hTrie.SetValue("saddlebrown", 0x8B4513);
+	hTrie.SetValue("salmon", 0xFA8072);
+	hTrie.SetValue("sandybrown", 0xF4A460);
+	hTrie.SetValue("seagreen", 0x2E8B57);
+	hTrie.SetValue("seashell", 0xFFF5EE);
+	hTrie.SetValue("selfmade", 0x70B04A); // same as Self-Made item quality in TF2
+	hTrie.SetValue("sienna", 0xA0522D);
+	hTrie.SetValue("silver", 0xC0C0C0);
+	hTrie.SetValue("skyblue", 0x87CEEB);
+	hTrie.SetValue("slateblue", 0x6A5ACD);
+	hTrie.SetValue("slategray", 0x708090);
+	hTrie.SetValue("slategrey", 0x708090);
+	hTrie.SetValue("snow", 0xFFFAFA);
+	hTrie.SetValue("springgreen", 0x00FF7F);
+	hTrie.SetValue("steelblue", 0x4682B4);
+	hTrie.SetValue("strange", 0xCF6A32); // same as Strange item quality in TF2
+	hTrie.SetValue("tan", 0xD2B48C);
+	hTrie.SetValue("teal", 0x008080);
+	hTrie.SetValue("thistle", 0xD8BFD8);
+	hTrie.SetValue("tomato", 0xFF6347);
+	hTrie.SetValue("turquoise", 0x40E0D0);
+	hTrie.SetValue("uncommon", 0xB0C3D9); // same as Uncommon item rarity in Dota 2
+	hTrie.SetValue("unique", 0xFFD700); // same as Unique item quality in TF2
+	hTrie.SetValue("unusual", 0x8650AC); // same as Unusual item quality in TF2
+	hTrie.SetValue("valve", 0xA50F79); // same as Valve item quality in TF2
+	hTrie.SetValue("vintage", 0x476291); // same as Vintage item quality in TF2
+	hTrie.SetValue("violet", 0xEE82EE);
+	hTrie.SetValue("wheat", 0xF5DEB3);
+	hTrie.SetValue("white", 0xFFFFFF);
+	hTrie.SetValue("whitesmoke", 0xF5F5F5);
+	hTrie.SetValue("yellow", 0xFFFF00);
+	hTrie.SetValue("yellowgreen", 0x9ACD32);
+	
 	return hTrie;
 }


### PR DESCRIPTION
This is needed to fix a possible case where displayed messages to clients are set to an incorrect language (the previous cached one), due to SetGlobalTransTarget call missing in critical formatting functions (e.g. CPrintToChat), which this new version solves