### PR TITLE
Bump maximum maps to 2048

### DIFF
--- a/addons/sourcemod/scripting/customvotes.sp
+++ b/addons/sourcemod/scripting/customvotes.sp
@@ -10,7 +10,7 @@
 #define PLUGIN_NAME "Custom Votes"
 #define PLUGIN_VERSION "1.19.1U"
 #define MAX_VOTE_TYPES 32
-#define MAX_VOTE_MAPS 1024
+#define MAX_VOTE_MAPS 2048
 #define MAX_VOTE_OPTIONS 32
 #pragma semicolon 1;
 #pragma newdecls required;


### PR DESCRIPTION
Required for high map count servers, such as bhop servers where having over 1024 maps is commonplace.