### PR TITLE
Fix list votes load memory leak

### DIFF
--- a/addons/sourcemod/scripting/customvotes.sp
+++ b/addons/sourcemod/scripting/customvotes.sp
@@ -2525,16 +2525,14 @@ public void Config_Load()
 			}
 			case VoteType_List:
 			{
-				if(!KvGotoFirstSubKey(hKeyValues, false))
+				if(!KvJumpToKey(hKeyValues, "Options"))
 					continue;
 
-				do
+				if(KvGotoFirstSubKey(hKeyValues, false))
 				{
-					if(!KvGotoFirstSubKey(hKeyValues, false))
-						continue;
-
 					g_hArrayVoteOptionName[iVote] = CreateArray(16);
 					g_hArrayVoteOptionResult[iVote] = CreateArray(16);
+
 					do
 					{
 						// Vote option name
@@ -2548,15 +2546,18 @@ public void Config_Load()
 						PushArrayString(g_hArrayVoteOptionResult[iVote], strOptionResult);
 					}
 					while(KvGotoNextKey(hKeyValues, false));
+
 					KvGoBack(hKeyValues);
 				}
-				while(KvGotoNextKey(hKeyValues, false));
+
 				KvGoBack(hKeyValues);
 			}
 		}
-		iVote++;
+
+		++iVote;
 	}
-	while(KvGotoNextKey(hKeyValues, false));
+	while(KvGotoNextKey(hKeyValues));
+
 	CloseHandle(hKeyValues);
 
 	g_iVoteCount = iVote;


### PR DESCRIPTION
Hi,

Previous contributor here (fixed past memory leaks). I have casually found there were other leaks, still, arising every map change.

This PR fixes a memory leak at config parsing for List votes, as the code was pushing array strings in the wrong scope (a search loop).

The commit also enhances same parsing as the code located the assumed "Options" section in a brute force way (inadequately). Now it searches for the exact "Options" key for adding the List vote options.

Here you can see a SM Handles dump difference (using [this viewer](https://srcdslab.github.io/HandleDumpParser)), after running a HL2DM server for nearly 6 days, at ~15 minutes average per map:

![customvotes handles dump](https://user-images.githubusercontent.com/15228896/208460725-e4c219af-9028-4783-af6f-213db97dfe00.PNG)
